### PR TITLE
Facilitate deployment using serverless instead of cloudformation

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ const client = new ApolloClient({
 - [Chat App](./packages/chat-example-app) - React app
 - [Chat Server](./packages/chat-example-server)
   - contains AWS Lambda that handles HTTP, WebSocket and DynamoDB streams
-  - also contains example cloudformation template you can use to deploy your solution
+  - also includes serverless.yaml file for easy deployment
 
 ## Contributing
 

--- a/packages/chat-example-app/src/index.tsx
+++ b/packages/chat-example-app/src/index.tsx
@@ -7,8 +7,10 @@ import { render } from 'react-dom';
 import { ApolloProvider } from 'react-apollo';
 import { Box, MessageInput, Messages } from './components';
 
+const LAMBDA_WEBSOCKET = `wss://kwno10mgz7.execute-api.eu-north-1.amazonaws.com/dev`
+
 const wsClient = new Client({
-  uri: `wss://iz6r1n6jn8.execute-api.eu-central-1.amazonaws.com/development`,
+  uri: LAMBDA_WEBSOCKET,
 });
 const link = new WebSocketLink(wsClient);
 

--- a/packages/chat-example-server/.gitignore
+++ b/packages/chat-example-server/.gitignore
@@ -1,0 +1,6 @@
+# package directories
+node_modules
+jspm_packages
+
+# Serverless directories
+.serverless

--- a/packages/chat-example-server/README.md
+++ b/packages/chat-example-server/README.md
@@ -4,6 +4,8 @@
 
 Install `serverless` package system-wide via:
 
+(Make sure you have serverless v1.38 or later)
+
 ```bash
 npm install -g serverless
 ```

--- a/packages/chat-example-server/README.md
+++ b/packages/chat-example-server/README.md
@@ -1,5 +1,13 @@
 # chat-example-server
 
+## Install Serverless
+
+Install `serverless` package system-wide via:
+
+```bash
+npm install -g serverless
+```
+
 ## Deploy
 
 ```console
@@ -8,61 +16,6 @@ yarn deploy
 npm run deploy
 ```
 
-**After deploy you need to set up API Gateway V2 to able to listen to WebSocket, see below**
+## Update 
 
-## 1. Create API
-
-1. In the API Gateway console, choose **Create API**, **New API**.
-2. Under **Choose the protocol**, choose **WebSocket**.
-3. For **API name**, enter **Chat example server ws**.
-4. For **Route Selection Expression**, enter `\$default`.
-5. Enter a description if you’d like and click Create API.
-
-## 2. Manage routes
-
-1. In the API Gateway console, under **Chat example server ws**, choose **Routes**.
-
-### 2.1. Connect route
-
-⚠️ This route is need to register connection.
-
-1. Choose **\$connect** in **Routes**
-2. Set **Integration type** to **Lambda Function**
-3. Check **Use Lambda Proxy integration**
-4. In **Lambda Function** select deployed **chat-example-server**
-5. Click **Save** and accept **Add Permission to Lambda Function**
-6. Now **Add integration response** button appears, **Click it**
-7. Done
-
-### 2.2 Disconnect route
-
-⚠️ This route is need to unregister connection.
-
-1. Choose **\$disconnect** in **Routes**
-2. Set **Integration type** to **Lambda Function**
-3. Check **Use Lambda Proxy integration**
-4. In **Lambda Function** select deployed **chat-example-server**
-5. Click **Save** and accept **Add Permission to Lambda Function**
-6. Now **Add integration response** button appears, **Click it**
-7. Done
-
-### 2.3 Message route
-
-⚠️ This route is need so you can send operations to the GraphQL server.
-
-1. Choose **\$default** in **Routes**
-2. Set **Integration type** to **Lambda Function**
-3. Check **Use Lambda Proxy integration**
-4. In **Lambda Function** select deployed **chat-example-server**
-5. Click **Save** and accept **Add Permission to Lambda Function**
-6. Now **Add integration response** button appears, **Click it**
-7. Done
-
-## 3. Deploy API
-
-1. In **Routes** click on **Actions** dropdown button
-2. Click on **Deploy API**
-3. In **Deploy API** modal choose **[New Stage]** under **Deployment stage**
-4. As **Stage Name** type **development**
-5. Copy **WebSocket URL** and use it in your application
-6. Done
+Update **LAMBDA_WEBSOCKET** inside `chat-example-app/src/index.tsx` with your new endpoint from serverless deployment.

--- a/packages/chat-example-server/package.json
+++ b/packages/chat-example-server/package.json
@@ -17,7 +17,7 @@
   "scripts": {
     "build": "ncc build src/index.ts -o dist",
     "predeploy": "yarn run build",
-    "deploy": "aws cloudformation package --template-file cloudformation.yml --s3-bucket brosoft-chat-app --output-template-file dist/template.yml && aws cloudformation deploy --template-file dist/template.yml --stack-name example-chat-server --capabilities CAPABILITY_IAM",
+    "deploy": "sls deploy",
     "prestart": "yarn run build",
     "start": "node dist/index.js"
   }

--- a/packages/chat-example-server/serverless.yml
+++ b/packages/chat-example-server/serverless.yml
@@ -1,0 +1,99 @@
+service: graphql-server-demo # NOTE: update this with your service name
+
+provider:
+  name: aws
+  runtime: nodejs8.10
+
+  iamRoleStatements:
+    - Effect: Allow
+      Action:
+        - execute-api:ManageConnections
+      Resource: 'arn:aws:execute-api:*:*:*/development/POST/@connections/*'
+    - Effect: Allow
+      Action:
+        - dynamodb:DeleteItem
+        - dynamodb:GetItem
+        - dynamodb:PutItem
+      Resource: !GetAtt ConnectionsDynamoDBTable.Arn
+    - Effect: Allow
+      Action:
+        - dynamodb:DescribeStream
+        - dynamodb:GetRecords
+        - dynamodb:GetShardIterator
+        - dynamodb:ListStreams
+      Resource: !GetAtt EventsDynamoDBTable.StreamArn
+    - Effect: Allow
+      Action:
+        - dynamodb:PutItem
+      Resource: !GetAtt EventsDynamoDBTable.Arn
+    - Effect: Allow
+      Action:
+        - dynamodb:BatchWriteItem
+        - dynamodb:DeleteItem
+        - dynamodb:GetItem
+        - dynamodb:PutItem
+        - dynamodb:Query
+      Resource: !GetAtt SubscriptionsDynamoDBTable.Arn
+
+functions:
+  mainHandler:
+    handler: dist/index.handler
+    events:
+      - websocket: 
+         route: $connect
+      - websocket: 
+         route: $disconnect
+      - websocket: $default
+      - stream:
+          type: dynamodb
+          arn:
+            Fn::GetAtt: [ EventsDynamoDBTable, StreamArn ]
+
+resources:
+  Resources:
+    ConnectionsDynamoDBTable:
+      Type: AWS::DynamoDB::Table
+      Properties:
+        # see DynamoDBConnectionManager
+        TableName: Connections
+        AttributeDefinitions:
+          - AttributeName: id
+            AttributeType: S
+        BillingMode: PAY_PER_REQUEST
+        KeySchema:
+          # connection id
+          - AttributeName: id
+            KeyType: HASH
+
+    SubscriptionsDynamoDBTable:
+      Type: AWS::DynamoDB::Table
+      Properties:
+        # see DynamoDBSubscriptionManager
+        TableName: Subscriptions
+        AttributeDefinitions:
+          - AttributeName: event
+            AttributeType: S
+          - AttributeName: subscriptionId
+            AttributeType: S
+        BillingMode: PAY_PER_REQUEST
+        KeySchema:
+          - AttributeName: event
+            KeyType: HASH
+          - AttributeName: subscriptionId
+            KeyType: RANGE
+
+    EventsDynamoDBTable:
+      Type: AWS::DynamoDB::Table
+      Properties:
+        # see DynamoDBEventStore
+        TableName: Events
+        KeySchema:
+          - AttributeName: id
+            KeyType: HASH
+        BillingMode: PAY_PER_REQUEST
+        # see ISubscriptionEvent
+        AttributeDefinitions:
+          - AttributeName: id
+            AttributeType: S
+        StreamSpecification:
+          StreamViewType: NEW_IMAGE


### PR DESCRIPTION
I left the [cloudformation.yaml](https://github.com/michalkvasnicak/aws-lambda-graphql/blob/master/packages/chat-example-server/cloudformation.yml) file for reference, but could be removed in the future, since it's completely replaced by the [serverless.yaml](https://github.com/guerrerocarlos/aws-lambda-graphql/blob/master/packages/chat-example-server/serverless.yml) file.

