### PR TITLE
fix: update reconnected state to call processOperations

### DIFF
--- a/packages/aws-lambda-graphql/src/client/machine.ts
+++ b/packages/aws-lambda-graphql/src/client/machine.ts
@@ -74,6 +74,10 @@ const clientMachine = Machine<ClientContext, ClientStateSchema, ClientEvents>({
       },
     },
     reconnected: {
+      invoke: {
+        id: 'processOperations',
+        src: services.processOperations,
+      },
       on: {
         // connections has been closed :(
         DISCONNECTED: [


### PR DESCRIPTION
Resolves #24 

Was able to reproduce the original error by opening a WebSocket connection and letting it time out. We transition to the `reconnecting` and then `reconnected` states properly, but then any operations after that are not sent anywhere because processing was never started again.

After adding this fix, we reconnect with a new WebSocket and then operations are sent successfully after that.

I think it's also important to note in the documentation somewhere that `reconnectAttempts` _does not_ affect the amount of times a reconnect is attempted after timing out, it only affects reconnect attempts after an error connecting in the first place. Might be worth adding another property to control that, but can be done in another PR.

If you choose to merge this, it would be nice if you could create a new release immediately after. I have a production environment currently suffering from this issue :)