### PR TITLE
Fix `unsubscribeAllByConnectionId` when there is nothing to unsubscribe from

### DIFF
--- a/packages/aws-lambda-graphql/src/DynamoDBSubscriptionManager.ts
+++ b/packages/aws-lambda-graphql/src/DynamoDBSubscriptionManager.ts
@@ -226,7 +226,7 @@ class DynamoDBSubscriptionManager implements ISubscriptionManager {
         })
         .promise();
 
-      if (Items == null) {
+      if (Items == null || !Items.length) {
         return;
       }
 


### PR DESCRIPTION
DynamoDB document client `scan` [will return empty array on no result](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/DynamoDB/DocumentClient.html#scan-property), which will result in `batchWrite` executing with no actual writes and giving following error:

> ValidationException: 1 validation error detected: Value '{SubscriptionOperations=[], Subscriptions=[]}' at 'requestItems' failed to satisfy constraint: Map value must satisfy constraint: [Member must have length less than or equal to 25, Member must have length greater than or equal to 1]