### PR TITLE
Implement server lifecycle methods

### DIFF
--- a/packages/aws-lambda-graphql/package.json
+++ b/packages/aws-lambda-graphql/package.json
@@ -51,7 +51,7 @@
     "@types/node": "8.10.39",
     "@types/websocket": "^0.0.40",
     "apollo-link": "1.2.11",
-    "aws-sdk": "2.464.0",
+    "aws-sdk": "2.521.0",
     "graphql": "14.3.1",
     "graphql-subscriptions": "1.1.0",
     "graphql-tag": "^2.10.0",

--- a/packages/aws-lambda-graphql/src/DynamoDBConnectionManager.ts
+++ b/packages/aws-lambda-graphql/src/DynamoDBConnectionManager.ts
@@ -5,6 +5,7 @@ import {
   IConnectEvent,
   IConnectionManager,
   ISubscriptionManager,
+  IConnectionData,
 } from './types';
 
 export class ConnectionNotFoundError extends ExtendableError {}
@@ -53,8 +54,8 @@ class DynamoDBConnectionManager implements IConnectionManager {
     return result.Item as IConnection;
   };
 
-  setConnectionContext = async (
-    context: Object,
+  setConnectionData = async (
+    data: IConnectionData,
     connection: IConnection,
   ): Promise<void> => {
     await this.db
@@ -63,9 +64,9 @@ class DynamoDBConnectionManager implements IConnectionManager {
         Key: {
           id: connection.id,
         },
-        UpdateExpression: 'set #data.context = :context',
+        UpdateExpression: 'set #data = :data',
         ExpressionAttributeValues: {
-          ':context': context,
+          ':data': data,
         },
         ExpressionAttributeNames: {
           '#data': 'data',
@@ -98,7 +99,7 @@ class DynamoDBConnectionManager implements IConnectionManager {
   }: IConnectEvent): Promise<IConnection> => {
     const connection: IConnection = {
       id: connectionId,
-      data: { endpoint, context: {} },
+      data: { endpoint, context: {}, isInitialized: false },
     };
 
     await this.db

--- a/packages/aws-lambda-graphql/src/WebSocketConnectionManager.ts
+++ b/packages/aws-lambda-graphql/src/WebSocketConnectionManager.ts
@@ -1,6 +1,11 @@
 import * as WebSocket from 'ws';
 import { ExtendableError } from './errors';
-import { IConnection, IConnectEvent, IConnectionManager } from './types';
+import {
+  IConnection,
+  IConnectEvent,
+  IConnectionManager,
+  IConnectionData,
+} from './types';
 
 export class ConnectionNotFoundError extends ExtendableError {}
 
@@ -38,17 +43,14 @@ class WebSocketConnectionManager implements IConnectionManager {
     return connection;
   };
 
-  setConnectionContext = async (
-    context: Object,
+  setConnectionData = async (
+    data: IConnectionData,
     connection: WSConnection,
   ): Promise<void> => {
     this.connections.set(connection.id, {
       socket: connection.socket,
       id: connection.id,
-      data: {
-        ...connection.data,
-        context,
-      },
+      data,
     });
   };
 
@@ -71,7 +73,7 @@ class WebSocketConnectionManager implements IConnectionManager {
     const connection: WSConnection = {
       socket,
       id: connectionId,
-      data: { endpoint, context: {} },
+      data: { endpoint, context: {}, isInitialized: false },
     };
 
     this.connections.set(connectionId, connection);

--- a/packages/aws-lambda-graphql/src/WebSocketConnectionManager.ts
+++ b/packages/aws-lambda-graphql/src/WebSocketConnectionManager.ts
@@ -38,6 +38,20 @@ class WebSocketConnectionManager implements IConnectionManager {
     return connection;
   };
 
+  setConnectionContext = async (
+    context: Object,
+    connection: WSConnection,
+  ): Promise<void> => {
+    this.connections.set(connection.id, {
+      socket: connection.socket,
+      id: connection.id,
+      data: {
+        ...connection.data,
+        context,
+      },
+    });
+  };
+
   setLegacyProtocol = async (connection: WSConnection): Promise<void> => {
     this.connections.set(connection.id, {
       socket: connection.socket,
@@ -57,7 +71,7 @@ class WebSocketConnectionManager implements IConnectionManager {
     const connection: WSConnection = {
       socket,
       id: connectionId,
-      data: { endpoint },
+      data: { endpoint, context: {} },
     };
 
     this.connections.set(connectionId, connection);
@@ -80,6 +94,13 @@ class WebSocketConnectionManager implements IConnectionManager {
 
   unregisterConnection = async (connection: IConnection): Promise<void> => {
     this.connections.delete(connection.id);
+  };
+
+  closeConnection = async (connection: WSConnection): Promise<void> => {
+    setTimeout(() => {
+      // wait so we can send error message first
+      connection.socket.close(1011);
+    }, 10);
   };
 }
 

--- a/packages/aws-lambda-graphql/src/__mocks__/aws-sdk.ts
+++ b/packages/aws-lambda-graphql/src/__mocks__/aws-sdk.ts
@@ -4,9 +4,15 @@ const postToConnectionPromiseMock = jest.fn();
 const postToConnectionMock = jest.fn(() => ({
   promise: postToConnectionPromiseMock,
 }));
+const deleteConnectionPromiseMock = jest.fn();
+const deleteConnectionMock = jest.fn(() => ({
+  promise: deleteConnectionPromiseMock,
+}));
 
 class ApiGatewayManagementApi {
   postToConnection = postToConnectionMock;
+
+  deleteConnection = deleteConnectionMock;
 }
 
 const batchWritePromiseMock = jest.fn();
@@ -17,6 +23,8 @@ const getPromiseMock = jest.fn();
 const getMock = jest.fn(() => ({ promise: getPromiseMock }));
 const putPromiseMock = jest.fn();
 const putMock = jest.fn(() => ({ promise: putPromiseMock }));
+const updatePromiseMock = jest.fn();
+const updateMock = jest.fn(() => ({ promise: updatePromiseMock }));
 const queryPromiseMock = jest.fn();
 const queryMock = jest.fn(() => ({ promise: queryPromiseMock }));
 const transactWritePromiseMock = jest.fn();
@@ -32,6 +40,8 @@ class DocumentClient {
   get = getMock;
 
   put = putMock;
+
+  update = updateMock;
 
   query = queryMock;
 
@@ -51,8 +61,12 @@ export {
   deletePromiseMock,
   postToConnectionMock,
   postToConnectionPromiseMock,
+  deleteConnectionMock,
+  deleteConnectionPromiseMock,
   putMock,
   putPromiseMock,
+  updateMock,
+  updatePromiseMock,
   queryMock,
   queryPromiseMock,
   transactWriteMock,

--- a/packages/aws-lambda-graphql/src/__tests__/DynamoDBConnectionManager.test.ts
+++ b/packages/aws-lambda-graphql/src/__tests__/DynamoDBConnectionManager.test.ts
@@ -62,6 +62,7 @@ describe('DynamoDBConnectionManager', () => {
         data: {
           endpoint: '',
           context: {},
+          isInitialized: false,
         },
       });
 
@@ -100,14 +101,14 @@ describe('DynamoDBConnectionManager', () => {
     });
   });
 
-  describe('setConnectionContext', () => {
+  describe('setConnectionData', () => {
     const manager = new DynamoDBConnectionManager({
       subscriptions: subscriptionManager,
     });
 
-    it('updates connection context', async () => {
+    it('updates connection data', async () => {
       await expect(
-        manager.setConnectionContext({}, { id: 'id', data: {} }),
+        manager.setConnectionData({}, { id: 'id', data: {} }),
       ).resolves.toBeUndefined();
       expect(updateMock as jest.Mock).toHaveBeenCalledTimes(1);
     });

--- a/packages/aws-lambda-graphql/src/__tests__/DynamoDBConnectionManager.test.ts
+++ b/packages/aws-lambda-graphql/src/__tests__/DynamoDBConnectionManager.test.ts
@@ -12,9 +12,17 @@ import {
   // @ts-ignore
   postToConnectionPromiseMock,
   // @ts-ignore
+  deleteConnectionMock,
+  // @ts-ignore
+  deleteConnectionPromiseMock,
+  // @ts-ignore
   putMock,
   // @ts-ignore
   putPromiseMock,
+  // @ts-ignore
+  updateMock,
+  // @ts-ignore
+  updatePromiseMock,
 } from 'aws-sdk';
 import {
   DynamoDBConnectionManager,
@@ -30,12 +38,15 @@ describe('DynamoDBConnectionManager', () => {
     deleteMock.mockClear();
     getMock.mockClear();
     postToConnectionMock.mockClear();
+    deleteConnectionMock.mockClear();
     putMock.mockClear();
     deletePromiseMock.mockReset();
     getPromiseMock.mockReset();
     postToConnectionPromiseMock.mockReset();
+    deleteConnectionPromiseMock.mockReset();
     putPromiseMock.mockReset();
     subscriptionManager.unsubscribeAllByConnectionId.mockReset();
+    updatePromiseMock.mockReset();
   });
 
   describe('registerConnection', () => {
@@ -50,6 +61,7 @@ describe('DynamoDBConnectionManager', () => {
         id: 'id',
         data: {
           endpoint: '',
+          context: {},
         },
       });
 
@@ -85,6 +97,19 @@ describe('DynamoDBConnectionManager', () => {
       });
 
       expect(getMock as jest.Mock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('setConnectionContext', () => {
+    const manager = new DynamoDBConnectionManager({
+      subscriptions: subscriptionManager,
+    });
+
+    it('updates connection context', async () => {
+      await expect(
+        manager.setConnectionContext({}, { id: 'id', data: {} }),
+      ).resolves.toBeUndefined();
+      expect(updateMock as jest.Mock).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -162,6 +187,18 @@ describe('DynamoDBConnectionManager', () => {
       ).resolves.toBeUndefined();
 
       expect(deletePromiseMock as jest.Mock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('closeConnection', () => {
+    const manager = new DynamoDBConnectionManager({
+      subscriptions: subscriptionManager,
+    });
+    it('closes connection', async () => {
+      await expect(
+        manager.closeConnection({ id: 'id', data: {} }),
+      ).resolves.toBeUndefined();
+      expect(deleteConnectionPromiseMock).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/packages/aws-lambda-graphql/src/__tests__/createWsHandler.test.ts
+++ b/packages/aws-lambda-graphql/src/__tests__/createWsHandler.test.ts
@@ -418,6 +418,7 @@ describe('createWsHandler', () => {
       ).resolves.toEqual(
         expect.objectContaining({
           body: formatMessage({
+            id,
             type: SERVER_EVENT_TYPES.GQL_ERROR,
             payload: { message: 'Prohibited connection!' },
           }),

--- a/packages/aws-lambda-graphql/src/__tests__/createWsHandler.test.ts
+++ b/packages/aws-lambda-graphql/src/__tests__/createWsHandler.test.ts
@@ -418,7 +418,6 @@ describe('createWsHandler', () => {
       ).resolves.toEqual(
         expect.objectContaining({
           body: formatMessage({
-            id,
             type: SERVER_EVENT_TYPES.GQL_ERROR,
             payload: { message: 'Prohibited connection!' },
           }),

--- a/packages/aws-lambda-graphql/src/__tests__/createWsHandler.test.ts
+++ b/packages/aws-lambda-graphql/src/__tests__/createWsHandler.test.ts
@@ -141,6 +141,34 @@ describe('createWsHandler', () => {
       expect(connectionManager.unregisterConnection).toHaveBeenCalledTimes(1);
       expect(connectionManager.unregisterConnection).toHaveBeenCalledWith({});
     });
+
+    it('calls onDisconnect', async () => {
+      const onDisconnect = jest.fn();
+      const handler = createWsHandler({
+        connectionManager,
+        schema: createSchema(),
+        onDisconnect,
+      } as any);
+
+      connectionManager.hydrateConnection.mockResolvedValueOnce({});
+
+      await expect(
+        handler(
+          {
+            requestContext: {
+              connectionId: '1',
+              domainName: 'domain',
+              routeKey: '$disconnect',
+              stage: 'stage',
+            } as any,
+          } as any,
+          {} as any,
+        ),
+      ).resolves.toBeUndefined();
+
+      expect(onDisconnect).toHaveBeenCalledTimes(1);
+      expect(onDisconnect).toHaveBeenCalledWith({});
+    });
   });
 
   describe('message phase', () => {

--- a/packages/aws-lambda-graphql/src/__tests__/createWsHandler.test.ts
+++ b/packages/aws-lambda-graphql/src/__tests__/createWsHandler.test.ts
@@ -433,11 +433,13 @@ describe('createWsHandler', () => {
       expect(connectionManager.sendToConnection).toHaveBeenCalledTimes(1);
     });
 
-    it('returns http 200 with GQL_DATA on query operation', async () => {
+    it('returns http 200 with GQL_DATA on query operation and calls onOperationComplete', async () => {
+      const onOperationComplete = jest.fn();
       const handler = createWsHandler({
         connectionManager,
         subscriptionManager,
         schema: createSchema(),
+        onOperationComplete,
       } as any);
       const id = ulid();
 
@@ -485,6 +487,11 @@ describe('createWsHandler', () => {
         false,
       );
       expect(connectionManager.sendToConnection).toHaveBeenCalledTimes(1);
+      expect(onOperationComplete).toHaveBeenCalledTimes(1);
+      expect(onOperationComplete).toHaveBeenCalledWith(
+        { data: { isInitialized: true } },
+        id,
+      );
     });
 
     it('returns http 200 with GQL_DATA on mutation operation', async () => {
@@ -599,11 +606,13 @@ describe('createWsHandler', () => {
       expect(subscriptionManager.subscribe).toHaveBeenCalledTimes(1);
     });
 
-    it('returns http 200 with GQL_COMPLETE on unsubscibe', async () => {
+    it('returns http 200 with GQL_COMPLETE on unsubscibe and calls onOperationComplete', async () => {
+      const onOperationComplete = jest.fn();
       const handler = createWsHandler({
         connectionManager,
         subscriptionManager,
         schema: createSchema(),
+        onOperationComplete,
       } as any);
       const id = ulid();
 
@@ -644,6 +653,11 @@ describe('createWsHandler', () => {
       );
       expect(subscriptionManager.unsubscribeOperation).toHaveBeenCalledTimes(1);
       expect(connectionManager.sendToConnection).toHaveBeenCalledTimes(1);
+      expect(onOperationComplete).toHaveBeenCalledTimes(1);
+      expect(onOperationComplete).toHaveBeenCalledWith(
+        { data: { isInitialized: true } },
+        id,
+      );
     });
 
     it('returns http 200 with GQL_DATA on invalid operation', async () => {

--- a/packages/aws-lambda-graphql/src/__tests__/createWsHandler.test.ts
+++ b/packages/aws-lambda-graphql/src/__tests__/createWsHandler.test.ts
@@ -419,7 +419,7 @@ describe('createWsHandler', () => {
         expect.objectContaining({
           body: formatMessage({
             type: SERVER_EVENT_TYPES.GQL_ERROR,
-            payload: { message: 'Connection is not initialized!' },
+            payload: { message: 'Prohibited connection!' },
           }),
           statusCode: 401,
         }),

--- a/packages/aws-lambda-graphql/src/__tests__/createWsHandler.test.ts
+++ b/packages/aws-lambda-graphql/src/__tests__/createWsHandler.test.ts
@@ -147,6 +147,7 @@ describe('createWsHandler', () => {
     const connectionManager = {
       hydrateConnection: jest.fn(),
       sendToConnection: jest.fn(),
+      setConnectionContext: jest.fn(),
     };
     const subscriptionManager = {
       subscribe: jest.fn(),
@@ -156,6 +157,7 @@ describe('createWsHandler', () => {
     beforeEach(() => {
       connectionManager.hydrateConnection.mockReset();
       connectionManager.sendToConnection.mockReset();
+      connectionManager.setConnectionContext.mockReset();
       subscriptionManager.subscribe.mockReset();
       subscriptionManager.unsubscribeOperation.mockReset();
     });
@@ -199,7 +201,7 @@ describe('createWsHandler', () => {
       );
     });
 
-    it('returns http 200 with GQL_CONNECTION_ACK on connection_init operation', async () => {
+    it('returns http 200 with GQL_CONNECTION_ACK on connection_init operation and sets context', async () => {
       const handler = createWsHandler({
         connectionManager,
         subscriptionManager,
@@ -212,7 +214,9 @@ describe('createWsHandler', () => {
         handler(
           {
             body: formatMessage({
-              payload: {},
+              payload: {
+                contextAttribute: 'contextAttributeValue',
+              },
               type: CLIENT_EVENT_TYPES.GQL_CONNECTION_INIT,
             }),
             requestContext: {
@@ -239,6 +243,11 @@ describe('createWsHandler', () => {
         false,
       );
       expect(connectionManager.sendToConnection).toHaveBeenCalledTimes(1);
+      expect(connectionManager.setConnectionContext).toHaveBeenCalledTimes(1);
+      expect(connectionManager.setConnectionContext).toHaveBeenCalledWith(
+        { contextAttribute: 'contextAttributeValue' },
+        {},
+      );
     });
 
     it('returns http 200 with GQL_DATA on query operation', async () => {

--- a/packages/aws-lambda-graphql/src/__tests__/createWsHandler.test.ts
+++ b/packages/aws-lambda-graphql/src/__tests__/createWsHandler.test.ts
@@ -419,7 +419,7 @@ describe('createWsHandler', () => {
         expect.objectContaining({
           body: formatMessage({
             type: SERVER_EVENT_TYPES.GQL_ERROR,
-            payload: { message: 'Prohibited connection!' },
+            payload: { message: 'Connection is not initialized!' },
           }),
           statusCode: 401,
         }),

--- a/packages/aws-lambda-graphql/src/createDynamoDBEventProcessor.ts
+++ b/packages/aws-lambda-graphql/src/createDynamoDBEventProcessor.ts
@@ -88,6 +88,7 @@ function createDynamoDBEventProcessor({
               schema,
               event: {} as any, // we don't have an API GW event here
               lambdaContext,
+              context: subscriber.connection.data.context,
               connection: subscriber.connection,
               operation: subscriber.operation,
               pubSub: pubSub as any,

--- a/packages/aws-lambda-graphql/src/createMemoryEventProcessor.ts
+++ b/packages/aws-lambda-graphql/src/createMemoryEventProcessor.ts
@@ -78,6 +78,7 @@ function createMemoryEventProcessor({
               schema,
               event: {} as any, // we don't have api gateway event here
               lambdaContext: lambdaContext as any, // we don't have a lambda's context here
+              context: subscriber.connection.data.context,
               connection: subscriber.connection,
               operation: subscriber.operation,
               pubSub: pubSub as any,

--- a/packages/aws-lambda-graphql/src/createWsHandler.ts
+++ b/packages/aws-lambda-graphql/src/createWsHandler.ts
@@ -37,6 +37,7 @@ interface WSHandlerOptions {
     | Promise<boolean | { [key: string]: any }>
     | boolean
     | { [key: string]: any };
+  onDisconnect?: (connection: IConnection) => void;
   /**
    * An optional array of validation rules that will be applied on the document
    * in additional to those defined by the GraphQL spec.
@@ -50,6 +51,7 @@ function createWsHandler({
   schema,
   subscriptionManager,
   onConnect,
+  onDisconnect,
   validationRules,
 }: WSHandlerOptions): APIGatewayV2Handler {
   return async function serveWebSocket(event, lambdaContext) {
@@ -80,6 +82,11 @@ function createWsHandler({
           const connection = await connectionManager.hydrateConnection(
             event.requestContext.connectionId,
           );
+
+          if (onDisconnect) {
+            onDisconnect(connection);
+          }
+
           await connectionManager.unregisterConnection(connection);
 
           // eslint-disable-next-line consistent-return

--- a/packages/aws-lambda-graphql/src/createWsHandler.ts
+++ b/packages/aws-lambda-graphql/src/createWsHandler.ts
@@ -16,6 +16,7 @@ import {
   ISubscriptionManager,
   IdentifiedOperationRequest,
   IConnection,
+  OperationRequest,
 } from './types';
 import { getProtocol } from './protocol/getProtocol';
 import { isLegacyOperation } from './helpers/isLegacyOperation';
@@ -30,6 +31,11 @@ interface WSHandlerOptions {
   context?: ExecuteOptions['context'];
   schema: GraphQLSchema;
   subscriptionManager: ISubscriptionManager;
+  onOperation?: (
+    message: OperationRequest,
+    params: Object,
+    connection: IConnection,
+  ) => Promise<Object> | Object;
   onOperationComplete?: (connection: IConnection, opId: string) => void;
   onConnect?: (
     messagePayload: { [key: string]: any },
@@ -51,6 +57,7 @@ function createWsHandler({
   context,
   schema,
   subscriptionManager,
+  onOperation,
   onOperationComplete,
   onConnect,
   onDisconnect,
@@ -218,6 +225,7 @@ function createWsHandler({
             pubSub: new PubSub(),
             useSubscriptions: true,
             validationRules,
+            onOperation,
           });
 
           if (isAsyncIterable(result) && useLegacyProtocol) {

--- a/packages/aws-lambda-graphql/src/createWsHandler.ts
+++ b/packages/aws-lambda-graphql/src/createWsHandler.ts
@@ -124,6 +124,10 @@ function createWsHandler({
                   errorResponse,
                 );
                 await connectionManager.closeConnection(connection);
+                return {
+                  body: errorResponse,
+                  statusCode: 401,
+                };
               }
             }
 

--- a/packages/aws-lambda-graphql/src/createWsHandler.ts
+++ b/packages/aws-lambda-graphql/src/createWsHandler.ts
@@ -168,10 +168,9 @@ function createWsHandler({
             // refuse connection which did not send GQL_CONNECTION_INIT operation
             const errorResponse = formatMessage({
               type: SERVER_EVENT_TYPES.GQL_ERROR,
-              payload: { message: 'Prohibited connection!' },
+              payload: { message: 'Connection is not initialized!' },
             });
             await connectionManager.sendToConnection(connection, errorResponse);
-            await connectionManager.closeConnection(connection);
             return {
               body: errorResponse,
               statusCode: 401,

--- a/packages/aws-lambda-graphql/src/createWsHandler.ts
+++ b/packages/aws-lambda-graphql/src/createWsHandler.ts
@@ -174,7 +174,6 @@ function createWsHandler({
           if (!useLegacyProtocol && !connection.data.isInitialized) {
             // refuse connection which did not send GQL_CONNECTION_INIT operation
             const errorResponse = formatMessage({
-              id: (operation as IdentifiedOperationRequest).operationId,
               type: SERVER_EVENT_TYPES.GQL_ERROR,
               payload: { message: 'Prohibited connection!' },
             });

--- a/packages/aws-lambda-graphql/src/createWsHandler.ts
+++ b/packages/aws-lambda-graphql/src/createWsHandler.ts
@@ -175,9 +175,10 @@ function createWsHandler({
             // refuse connection which did not send GQL_CONNECTION_INIT operation
             const errorResponse = formatMessage({
               type: SERVER_EVENT_TYPES.GQL_ERROR,
-              payload: { message: 'Connection is not initialized!' },
+              payload: { message: 'Prohibited connection!' },
             });
             await connectionManager.sendToConnection(connection, errorResponse);
+            await connectionManager.closeConnection(connection);
             return {
               body: errorResponse,
               statusCode: 401,

--- a/packages/aws-lambda-graphql/src/createWsHandler.ts
+++ b/packages/aws-lambda-graphql/src/createWsHandler.ts
@@ -207,17 +207,10 @@ function createWsHandler({
               statusCode: 200,
             };
           }
-          const executeContext =
-            connection.data && connection.data.context
-              ? {
-                  ...connection.data.context,
-                  context,
-                }
-              : context;
           const result = await execute({
             connection,
             connectionManager,
-            context: executeContext,
+            context,
             event,
             lambdaContext,
             operation: operation as IdentifiedOperationRequest,

--- a/packages/aws-lambda-graphql/src/createWsHandler.ts
+++ b/packages/aws-lambda-graphql/src/createWsHandler.ts
@@ -174,6 +174,7 @@ function createWsHandler({
           if (!useLegacyProtocol && !connection.data.isInitialized) {
             // refuse connection which did not send GQL_CONNECTION_INIT operation
             const errorResponse = formatMessage({
+              id: (operation as IdentifiedOperationRequest).operationId,
               type: SERVER_EVENT_TYPES.GQL_ERROR,
               payload: { message: 'Prohibited connection!' },
             });

--- a/packages/aws-lambda-graphql/src/execute.ts
+++ b/packages/aws-lambda-graphql/src/execute.ts
@@ -113,11 +113,16 @@ async function execute({
   // detect operation type
   const operationAST = getOperationAST(document, operation.operationName || '');
 
+  const connectionContext = connection.data ? connection.data.context : {};
+
   const baseParams = {
     query: document,
     variables: operation.variables,
     operationName: operation.operationName,
-    context: contextValue,
+    context: {
+      ...connectionContext,
+      ...contextValue,
+    },
     schema,
   };
   let promisedParams = Promise.resolve(baseParams);

--- a/packages/aws-lambda-graphql/src/fixtures/schema.ts
+++ b/packages/aws-lambda-graphql/src/fixtures/schema.ts
@@ -12,10 +12,11 @@ const typeDefs = /* GraphQL */ `
   type Query {
     delayed: Boolean!
     testQuery: String!
+    getFooPropertyFromContext: String
   }
 
   type Subscription {
-    textFeed(authorId: ID!): String!
+    textFeed(authorId: ID): String!
   }
 `;
 
@@ -60,6 +61,9 @@ function createSchema({
 
           return 'test';
         },
+        getFooPropertyFromContext(parent: any, args: any, ctx: IContext) {
+          return ctx.foo;
+        },
       },
       Subscription: {
         textFeed: {
@@ -76,7 +80,12 @@ function createSchema({
           },
           subscribe: withFilter(
             pubSub.subscribe('test'),
-            (payload, args) => payload.authorId === args.authorId,
+            (payload, args, ctx) => {
+              const subscriberAuthorId = ctx.authorId
+                ? ctx.authorId
+                : args.authorId;
+              return payload.authorId === subscriberAuthorId;
+            },
           ),
         },
       },

--- a/packages/aws-lambda-graphql/src/fixtures/server.ts
+++ b/packages/aws-lambda-graphql/src/fixtures/server.ts
@@ -27,7 +27,10 @@ class TestLambdaServer {
 
   wsServer: WSServer | undefined;
 
-  constructor({ port = 3001 }: { port?: number } = {}) {
+  constructor({
+    port = 3001,
+    onConnect,
+  }: { port?: number; onConnect?: Function } = {}) {
     this.eventStore = new MemoryEventStore();
     this.port = port;
 
@@ -41,6 +44,7 @@ class TestLambdaServer {
       schema,
       connectionManager: this.connectionManager,
       subscriptionManager: this.subscriptionManager,
+      onConnect,
     });
     this.eventProcessor = createMemoryEventProcessor({
       schema,

--- a/packages/aws-lambda-graphql/src/protocol/index.ts
+++ b/packages/aws-lambda-graphql/src/protocol/index.ts
@@ -43,6 +43,9 @@ export interface GQLOperation {
 export interface GQLUnsubscribe {
   /** The ID of GQLOperation used to subscribe */
   id: string;
+  payload?: {
+    [key: string]: any;
+  };
   type: CLIENT_EVENT_TYPES.GQL_STOP | LEGACY_CLIENT_EVENT_TYPES.GQL_STOP;
 }
 

--- a/packages/aws-lambda-graphql/src/types/connections.ts
+++ b/packages/aws-lambda-graphql/src/types/connections.ts
@@ -8,16 +8,23 @@ export interface IConnection {
    * Extra connection data, this data is stored only upon registration
    * All values should be JSON serializable
    */
-  readonly data: {
-    [key: string]: any;
+  readonly data: IConnectionData;
+}
 
-    /**
-     * Connection context data provided from GQL_CONNECTION_INIT message or from onConnect method
-     * This data is passed to graphql resolvers' context
-     * All values should be JSON serializable
-     */
-    context: Object;
-  };
+export interface IConnectionData {
+  [key: string]: any;
+
+  /**
+   * Connection context data provided from GQL_CONNECTION_INIT message or from onConnect method
+   * This data is passed to graphql resolvers' context
+   * All values should be JSON serializable
+   */
+  context: Object;
+
+  /**
+   * Indicates whether connection sent GQL_CONNECTION_INIT message or
+   */
+  readonly isInitialized: boolean;
 }
 
 export interface IConnectEvent {
@@ -30,7 +37,7 @@ export interface IConnectionManager {
     connectionId: string,
     useLegacyProtocol?: boolean,
   ): Promise<IConnection>;
-  setConnectionContext(context: Object, connection: IConnection): Promise<void>;
+  setConnectionData(data: Object, connection: IConnection): Promise<void>;
   setLegacyProtocol(connection: IConnection): Promise<void>;
   registerConnection(event: IConnectEvent): Promise<IConnection>;
   sendToConnection(

--- a/packages/aws-lambda-graphql/src/types/connections.ts
+++ b/packages/aws-lambda-graphql/src/types/connections.ts
@@ -8,7 +8,16 @@ export interface IConnection {
    * Extra connection data, this data is stored only upon registration
    * All values should be JSON serializable
    */
-  readonly data: { [key: string]: any };
+  readonly data: {
+    [key: string]: any;
+
+    /**
+     * Connection context data provided from GQL_CONNECTION_INIT message or from onConnect method
+     * This data is passed to graphql resolvers' context
+     * All values should be JSON serializable
+     */
+    context: Object;
+  };
 }
 
 export interface IConnectEvent {
@@ -21,6 +30,7 @@ export interface IConnectionManager {
     connectionId: string,
     useLegacyProtocol?: boolean,
   ): Promise<IConnection>;
+  setConnectionContext(context: Object, connection: IConnection): Promise<void>;
   setLegacyProtocol(connection: IConnection): Promise<void>;
   registerConnection(event: IConnectEvent): Promise<IConnection>;
   sendToConnection(
@@ -28,4 +38,5 @@ export interface IConnectionManager {
     payload: string | Buffer,
   ): Promise<void>;
   unregisterConnection(connection: IConnection): Promise<void>;
+  closeConnection(connection: IConnection): Promise<void>;
 }

--- a/packages/aws-lambda-graphql/src/types/graphql.ts
+++ b/packages/aws-lambda-graphql/src/types/graphql.ts
@@ -40,6 +40,8 @@ export interface IContext {
     registerSubscriptions?: boolean;
     subscriptionManager: ISubscriptionManager;
   };
+
+  [key: string]: any;
 }
 
 export interface OperationRequest {


### PR DESCRIPTION
This implements [server lifecycle methods available in subscriptions-transport-ws](https://github.com/apollographql/subscriptions-transport-ws#constructoroptions-socketoptions--socketserver):
- **`onConnect`** fires on `GQL_CONNECTION_INIT` message, receives payload of said message and allows to reject connection, write some data to connection context which will be available during graphql resolver execution. If `onConnect` is not defined, we put everything in `GQL_CONNECTION_INIT` message payload to connection context.
- **`onDisconnect`** fires on `$disconnect`, receives connection object as argument
- **`onOperation`** fires on mutation, query and subscription start operations, receives message payload and connection object as arguments
- **`onOperationComplete`** fires on subscription stop operations, receives connection object and operation ID as arguments