### PR TITLE
Wait for connection to be initialized

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,8 @@ const wsHandler = createWsHandler({
   schema,
   subscriptionManager,
   // validationRules
+  // waitForInitialization (available from 0.11.0)
+  // waitForInitialization: { retryCount?: number, timeout?: number },
 });
 
 // use these handlers from your lambda and map them to

--- a/packages/aws-lambda-graphql/src/__tests__/createWsHandler.test.ts
+++ b/packages/aws-lambda-graphql/src/__tests__/createWsHandler.test.ts
@@ -385,10 +385,15 @@ describe('createWsHandler', () => {
         connectionManager,
         subscriptionManager,
         schema: createSchema(),
+        waitForInitialization: {
+          timeout: 4,
+          retryCount: 2,
+        },
       } as any);
       const id = ulid();
 
-      connectionManager.hydrateConnection.mockResolvedValueOnce({
+      // because of retry count of 2
+      connectionManager.hydrateConnection.mockResolvedValue({
         data: { isInitialized: false },
       });
 
@@ -425,7 +430,7 @@ describe('createWsHandler', () => {
         }),
       );
 
-      expect(connectionManager.hydrateConnection).toHaveBeenCalledTimes(1);
+      expect(connectionManager.hydrateConnection).toHaveBeenCalledTimes(3);
       expect(connectionManager.hydrateConnection).toHaveBeenCalledWith(
         '1',
         false,


### PR DESCRIPTION
Introduces new optional setting `waitForInitializiation: { retryCount?: number, timeout?: number }` to `createWsHandler()`.

- `retryCount` how many times should the handler hydrate connection?
- `timeout` how long should we wait until we hydrate connection again?


Closes #33 