### PR TITLE
Proper APIGateway response on $disconnect

### DIFF
--- a/packages/aws-lambda-graphql/src/__tests__/createWsHandler.test.ts
+++ b/packages/aws-lambda-graphql/src/__tests__/createWsHandler.test.ts
@@ -164,7 +164,11 @@ describe('createWsHandler', () => {
           } as any,
           {} as any,
         ),
-      ).resolves.toBeUndefined();
+      ).resolves.toEqual(
+        expect.objectContaining({
+          body: '',
+          statusCode: 200,
+      }),
 
       expect(onDisconnect).toHaveBeenCalledTimes(1);
       expect(onDisconnect).toHaveBeenCalledWith({});

--- a/packages/aws-lambda-graphql/src/__tests__/createWsHandler.test.ts
+++ b/packages/aws-lambda-graphql/src/__tests__/createWsHandler.test.ts
@@ -168,7 +168,8 @@ describe('createWsHandler', () => {
         expect.objectContaining({
           body: '',
           statusCode: 200,
-      })
+        }),
+      );
 
       expect(onDisconnect).toHaveBeenCalledTimes(1);
       expect(onDisconnect).toHaveBeenCalledWith({});

--- a/packages/aws-lambda-graphql/src/__tests__/createWsHandler.test.ts
+++ b/packages/aws-lambda-graphql/src/__tests__/createWsHandler.test.ts
@@ -168,7 +168,7 @@ describe('createWsHandler', () => {
         expect.objectContaining({
           body: '',
           statusCode: 200,
-      }),
+      })
 
       expect(onDisconnect).toHaveBeenCalledTimes(1);
       expect(onDisconnect).toHaveBeenCalledWith({});

--- a/packages/aws-lambda-graphql/src/createWsHandler.ts
+++ b/packages/aws-lambda-graphql/src/createWsHandler.ts
@@ -123,8 +123,10 @@ function createWsHandler({
 
           await connectionManager.unregisterConnection(connection);
 
-          // eslint-disable-next-line consistent-return
-          return;
+          return {
+            body: '',
+            statusCode: 200,
+          };
         }
         case '$default': {
           // here we are processing messages received from a client


### PR DESCRIPTION
I'm getting this error in APIGateway logs:

```
Endpoint response body before transformations: null
Execution failed due to configuration error: Malformed Lambda proxy response
```