### PR TITLE
add TTL support for dynamodb events

### DIFF
--- a/packages/aws-lambda-graphql/src/DynamoDBEventStore.ts
+++ b/packages/aws-lambda-graphql/src/DynamoDBEventStore.ts
@@ -1,19 +1,34 @@
 import { ulid } from 'ulid';
 import { DynamoDB } from 'aws-sdk';
 import { IEventStore, ISubscriptionEvent } from './types';
+import { computeTTL } from './helpers';
 
-type Options = {
+const DEFAULT_TTL = 7200;
+
+interface DynamoDBEventStoreOptions {
   eventsTable?: string;
-};
+  /**
+   * Optional TTL for events (stored in ttl field) in seconds
+   *
+   * Default value is 2 hours
+   */
+  ttl?: number;
+}
 
 class DynamoDBEventStore implements IEventStore {
   private db: DynamoDB.DocumentClient;
 
   private tableName: string;
 
-  constructor({ eventsTable = 'Events' }: Options = {}) {
+  private ttl: number;
+
+  constructor({
+    eventsTable = 'Events',
+    ttl = DEFAULT_TTL,
+  }: DynamoDBEventStoreOptions = {}) {
     this.db = new DynamoDB.DocumentClient();
     this.tableName = eventsTable;
+    this.ttl = ttl;
   }
 
   publish = async (event: ISubscriptionEvent): Promise<void> => {
@@ -23,6 +38,7 @@ class DynamoDBEventStore implements IEventStore {
         Item: {
           id: ulid(),
           ...event,
+          ttl: computeTTL(this.ttl),
         },
       })
       .promise();

--- a/packages/aws-lambda-graphql/src/__tests__/DynamoDBEventStore.test.ts
+++ b/packages/aws-lambda-graphql/src/__tests__/DynamoDBEventStore.test.ts
@@ -1,9 +1,10 @@
 // @ts-ignore
-import { putPromiseMock } from 'aws-sdk';
+import { putMock, putPromiseMock } from 'aws-sdk';
 import { DynamoDBEventStore } from '../DynamoDBEventStore';
 
 describe('DynamoDBEventStore', () => {
   beforeEach(() => {
+    putMock.mockClear();
     putPromiseMock.mockReset();
   });
 
@@ -20,5 +21,18 @@ describe('DynamoDBEventStore', () => {
     ).resolves.toBeUndefined();
 
     expect(putPromiseMock).toHaveBeenCalledTimes(1);
+    expect(putMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        TableName: 'Events',
+        Item: expect.objectContaining({
+          id: expect.stringMatching(/^[A-Z0-9]{26}$/),
+          event: 'test',
+          payload: {
+            custom: true,
+          },
+          ttl: expect.any(Number),
+        }),
+      }),
+    );
   });
 });

--- a/packages/aws-lambda-graphql/src/helpers/computeTTL.ts
+++ b/packages/aws-lambda-graphql/src/helpers/computeTTL.ts
@@ -1,0 +1,6 @@
+/**
+ * Computes TTL in UNIX timestamp with seconds precision
+ */
+export function computeTTL(ttl: number): number {
+  return Math.round(Date.now() / 1000 + ttl);
+}

--- a/packages/aws-lambda-graphql/src/helpers/index.ts
+++ b/packages/aws-lambda-graphql/src/helpers/index.ts
@@ -1,2 +1,3 @@
 export * from './extractEndpointFromEvent';
 export * from './parseOperationFromEvent';
+export * from './computeTTL';


### PR DESCRIPTION
Closes #47 

There is a new optional `ttl` field that could be passed to `DynamoDBEventStore`. It tells about the lifetime of an event in seconds (default value is 2 hours).

This library is not responsible for setting up the TTL on DynamoDB table so it's up on the user to actually set up TTL on Event's DynamoDB table field `ttl`.