### PR TITLE
Fix missing connection data context in dynamodb event processor

### DIFF
--- a/packages/aws-lambda-graphql/src/DynamoDBEventProcessor.ts
+++ b/packages/aws-lambda-graphql/src/DynamoDBEventProcessor.ts
@@ -28,7 +28,8 @@ export class DynamoDBEventProcessor<TServer extends Server = Server>
 
   public createHandler(server: TServer): DynamoDBStreamHandler {
     return async (lambdaEvent, lambdaContext) => {
-      const { connectionManager, subscriptionManager } = server;
+      const connectionManager = server.getConnectionManager();
+      const subscriptionManager = server.getSubscriptionManager();
       const { Records } = lambdaEvent;
 
       for (const record of Records) {

--- a/packages/aws-lambda-graphql/src/DynamoDBEventProcessor.ts
+++ b/packages/aws-lambda-graphql/src/DynamoDBEventProcessor.ts
@@ -28,11 +28,7 @@ export class DynamoDBEventProcessor<TServer extends Server = Server>
 
   public createHandler(server: TServer): DynamoDBStreamHandler {
     return async (lambdaEvent, lambdaContext) => {
-      const options = await server.createGraphQLServerOptions(
-        lambdaEvent as any,
-        lambdaContext,
-      );
-      const { connectionManager, subscriptionManager } = options.$$internal;
+      const { connectionManager, subscriptionManager } = server;
       const { Records } = lambdaEvent;
 
       for (const record of Records) {
@@ -62,6 +58,18 @@ export class DynamoDBEventProcessor<TServer extends Server = Server>
             .map(async subscriber => {
               // create PubSub for this subscriber
               const pubSub = new ArrayPubSub([event]);
+
+              const options = await server.createGraphQLServerOptions(
+                lambdaEvent as any,
+                lambdaContext,
+                {
+                  // this allows createGraphQLServerOptions() to append more extra data
+                  // to context from connection.data.context
+                  connection: subscriber.connection,
+                  operation: subscriber.operation,
+                  pubSub,
+                },
+              );
 
               // execute operation by executing it and then publishing the event
               const iterable = await execute({

--- a/packages/aws-lambda-graphql/src/Server.ts
+++ b/packages/aws-lambda-graphql/src/Server.ts
@@ -146,6 +146,14 @@ export class Server<
     this.subscriptionOptions = subscriptions;
   }
 
+  public getConnectionManager(): IConnectionManager {
+    return this.connectionManager;
+  }
+
+  public getSubscriptionManager(): ISubscriptionManager {
+    return this.subscriptionManager;
+  }
+
   public createGraphQLServerOptions(
     event: APIGatewayProxyEvent,
     context: LambdaContext,


### PR DESCRIPTION
Context value from connection.data was not provided for context resolver function in dynamodb event processor. Fix and a test.

Closes #64 