### PR TITLE
Fix timing issues with rapid protocol calls and missing dynamodb database fetch calls

### DIFF
--- a/packages/aws-lambda-graphql/package.json
+++ b/packages/aws-lambda-graphql/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "aws-lambda-graphql",
-  "version": "1.0.0-alpha.2",
+  "name": "sls-micro-subscription",
+  "version": "1.0.0-alpha.3",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
   "bugs": {

--- a/packages/aws-lambda-graphql/package.json
+++ b/packages/aws-lambda-graphql/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "sls-micro-subscription",
-  "version": "1.0.0-alpha.3",
+  "name": "aws-lambda-graphql",
+  "version": "1.0.0-alpha.2",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
   "bugs": {

--- a/packages/aws-lambda-graphql/src/Server.ts
+++ b/packages/aws-lambda-graphql/src/Server.ts
@@ -275,13 +275,18 @@ export class Server<
                 timeout: waitTimeout = 50,
               } = {},
             } = this.subscriptionOptions || {};
-            // hydrate connectiont
-            let connection = await this.connectionManager.hydrateConnection(
-              connectionId,
-            );
 
             // parse operation from body
             const operation = parseOperationFromEvent(event);
+
+            // hydrate connection
+            let connection = await this.connectionManager.hydrateConnection(
+              connectionId,
+              {
+                retryCount: isGQLConnectionInit(operation) ? waitRetryCount : 0,
+                timeout: waitTimeout,
+              },
+            );
 
             if (isGQLConnectionInit(operation)) {
               let newConnectionContext = operation.payload;

--- a/packages/aws-lambda-graphql/src/Server.ts
+++ b/packages/aws-lambda-graphql/src/Server.ts
@@ -355,7 +355,7 @@ export class Server<
                 return freshConnection;
               }
 
-              for (let i = 0; i < waitRetryCount; i++) {
+              for (let i = 0; i <= waitRetryCount; i++) {
                 freshConnection = await this.connectionManager.hydrateConnection(
                   connectionId,
                 );

--- a/packages/aws-lambda-graphql/src/Server.ts
+++ b/packages/aws-lambda-graphql/src/Server.ts
@@ -283,7 +283,7 @@ export class Server<
             let connection = await this.connectionManager.hydrateConnection(
               connectionId,
               {
-                retryCount: isGQLConnectionInit(operation) ? waitRetryCount : 0,
+                retryCount: 1,
                 timeout: waitTimeout,
               },
             );

--- a/packages/aws-lambda-graphql/src/__tests__/DynamoDBConnectionManager.test.ts
+++ b/packages/aws-lambda-graphql/src/__tests__/DynamoDBConnectionManager.test.ts
@@ -99,6 +99,25 @@ describe('DynamoDBConnectionManager', () => {
 
       expect(getMock as jest.Mock).toHaveBeenCalledTimes(1);
     });
+
+    it('hydrates connection with retry', async () => {
+      (getPromiseMock as jest.Mock)
+        .mockResolvedValueOnce({})
+        .mockResolvedValueOnce({
+          Item: { id: 'id', data: { endpoint: '' } },
+        });
+
+      await expect(
+        manager.hydrateConnection('id', { retryCount: 1 }),
+      ).resolves.toEqual({
+        id: 'id',
+        data: {
+          endpoint: '',
+        },
+      });
+
+      expect(getMock as jest.Mock).toHaveBeenCalledTimes(2);
+    });
   });
 
   describe('setConnectionData', () => {

--- a/packages/aws-lambda-graphql/src/__tests__/Server.test.ts
+++ b/packages/aws-lambda-graphql/src/__tests__/Server.test.ts
@@ -340,7 +340,7 @@ describe('Server', () => {
 
         expect(connectionManager.hydrateConnection).toHaveBeenCalledTimes(1);
         expect(connectionManager.hydrateConnection).toHaveBeenCalledWith('1', {
-          retryCount: 10,
+          retryCount: 1,
           timeout: 50,
         });
       });
@@ -379,7 +379,7 @@ describe('Server', () => {
 
         expect(connectionManager.hydrateConnection).toHaveBeenCalledTimes(1);
         expect(connectionManager.hydrateConnection).toHaveBeenCalledWith('1', {
-          retryCount: 10,
+          retryCount: 1,
           timeout: 50,
         });
         expect(connectionManager.sendToConnection).toHaveBeenCalledTimes(1);
@@ -599,7 +599,7 @@ describe('Server', () => {
           }),
         );
 
-        expect(connectionManager.hydrateConnection).toHaveBeenCalledTimes(3);
+        expect(connectionManager.hydrateConnection).toHaveBeenCalledTimes(4);
         expect(connectionManager.hydrateConnection).toHaveBeenCalledWith('1');
         expect(connectionManager.sendToConnection).toHaveBeenCalledTimes(1);
       });
@@ -658,7 +658,7 @@ describe('Server', () => {
 
         expect(connectionManager.hydrateConnection).toHaveBeenCalledTimes(1);
         expect(connectionManager.hydrateConnection).toHaveBeenCalledWith('1', {
-          retryCount: 0,
+          retryCount: 1,
           timeout: 50,
         });
         expect(connectionManager.sendToConnection).toHaveBeenCalledTimes(1);
@@ -717,7 +717,7 @@ describe('Server', () => {
 
         expect(connectionManager.hydrateConnection).toHaveBeenCalledTimes(1);
         expect(connectionManager.hydrateConnection).toHaveBeenCalledWith('1', {
-          retryCount: 0,
+          retryCount: 1,
           timeout: 50,
         });
         expect(connectionManager.sendToConnection).toHaveBeenCalledTimes(1);
@@ -832,7 +832,7 @@ describe('Server', () => {
 
         expect(connectionManager.hydrateConnection).toHaveBeenCalledTimes(1);
         expect(connectionManager.hydrateConnection).toHaveBeenCalledWith('1', {
-          retryCount: 0,
+          retryCount: 1,
           timeout: 50,
         });
         expect(subscriptionManager.unsubscribeOperation).toHaveBeenCalledTimes(
@@ -892,7 +892,7 @@ describe('Server', () => {
 
         expect(connectionManager.hydrateConnection).toHaveBeenCalledTimes(1);
         expect(connectionManager.hydrateConnection).toHaveBeenCalledWith('1', {
-          retryCount: 0,
+          retryCount: 1,
           timeout: 50,
         });
         expect(connectionManager.sendToConnection).toHaveBeenCalledTimes(1);

--- a/packages/aws-lambda-graphql/src/types/connections.ts
+++ b/packages/aws-lambda-graphql/src/types/connections.ts
@@ -27,13 +27,31 @@ export interface IConnectionData {
   readonly isInitialized: boolean;
 }
 
+export interface HydrateConnectionOptions {
+  /**
+   * How many times should we retry the connection query in case it fails for timing issues
+   *
+   * Default is 0
+   */
+  retryCount?: number;
+  /**
+   * How long should we wait until we try determine connection state again?
+   *
+   * Default is 50ms
+   */
+  timeout?: number;
+}
+
 export interface IConnectEvent {
   connectionId: string;
   endpoint: string;
 }
 
 export interface IConnectionManager {
-  hydrateConnection(connectionId: string): Promise<IConnection>;
+  hydrateConnection(
+    connectionId: string,
+    options?: HydrateConnectionOptions,
+  ): Promise<IConnection>;
   setConnectionData(data: Object, connection: IConnection): Promise<void>;
   registerConnection(event: IConnectEvent): Promise<IConnection>;
   sendToConnection(


### PR DESCRIPTION
When running locally on a very powerful machine like the one used in continuous integration the calls coming from the graphql client of:
1. $connect
2. $default -> gql_connect
3. $default -> gql_start

Can be quicker in the handler than the createConnection entry dynamodb call is taking to complete. This results into unexpected errors in the connection for local test runs and potentially also on production.

I fixed this by adding a retry mechanism to the connection hydration that is used for the initial call so it retrys once when the connection is not found.