### PR TITLE
Respond with 'Sec-WebSocket-Protocol' header on connect when requested

### DIFF
--- a/packages/aws-lambda-graphql/src/Server.ts
+++ b/packages/aws-lambda-graphql/src/Server.ts
@@ -239,6 +239,14 @@ export class Server<
 
             return {
               body: '',
+              headers:
+                event.headers &&
+                event.headers['Sec-WebSocket-Protocol'] === 'graphql-ws'
+                  ? {
+                      'Sec-WebSocket-Protocol':
+                        event.headers['Sec-WebSocket-Protocol'],
+                    }
+                  : undefined,
               statusCode: 200,
             };
           }


### PR DESCRIPTION
The subscription wasn't working with Playground because it requested with the `Sec-WebSocket-Protocol: graphql-ws` header and expected the same to be returned on connect.

With this error exactly:
`Error during WebSocket handshake: Sent non-empty 'Sec-WebSocket-Protocol' header but no response was received`

The proposed fix is to respond with that header when requested.
(Tested with both playground the the provided chat-example-app)