### PR TITLE
feat: ttl support for dynamodb connections and subscriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### [Unreleased](https://github.com/michalkvasnicak/aws-lambda-graphql/compare/aws-lambda-graphql@1.0.0-alpha.7...HEAD)
 
+#### Added
+
+- Added ttl support for dynamodb connections, subscriptions and subscriptionOperations , see [#90](https://github.com/michalkvasnicak/aws-lambda-graphql/pull/90).
+
 ### [v1.0.0-alpha.7](https://github.com/michalkvasnicak/aws-lambda-graphql/compare/aws-lambda-graphql@1.0.0-alpha.7...HEAD) - 2020-06-19
 
 #### Added

--- a/docs/serverless.yml
+++ b/docs/serverless.yml
@@ -87,6 +87,10 @@ resources:
           # connection id
           - AttributeName: id
             KeyType: HASH
+        # This one is optional (all connections have 2 hours of lifetime in ttl field but enabling TTL is up to you)
+        TimeToLiveSpecification:
+          AttributeName: ttl
+          Enabled: true
 
     SubscriptionsDynamoDBTable:
       Type: AWS::DynamoDB::Table
@@ -104,6 +108,10 @@ resources:
             KeyType: HASH
           - AttributeName: subscriptionId
             KeyType: RANGE
+        # This one is optional (all subscriptions have 2 hours of lifetime in ttl field but enabling TTL is up to you)
+        TimeToLiveSpecification:
+          AttributeName: ttl
+          Enabled: true
 
     SubscriptionOperationsDynamoDBTable:
       Type: AWS::DynamoDB::Table
@@ -117,6 +125,10 @@ resources:
         KeySchema:
           - AttributeName: subscriptionId
             KeyType: HASH
+        # This one is optional (all subscription operations have 2 hours of lifetime in ttl field but enabling TTL is up to you)
+        TimeToLiveSpecification:
+          AttributeName: ttl
+          Enabled: true
 
     EventsDynamoDBTable:
       Type: AWS::DynamoDB::Table

--- a/packages/aws-lambda-graphql/README.md
+++ b/packages/aws-lambda-graphql/README.md
@@ -86,6 +86,9 @@ Each connection is stored as [`IConnection` object](#iconnection).
 
 - **connectionsTable** (`string`, `optional`, `default: 'Connections'`) - name of DynamoDB table used to store connections
 - **subscriptions** (`ISubscriptionManager`, `required`) - subscription manager used to register subscriptions for connections.
+- **ttl** (`number`, `optional`, `default: 2 hours`)
+  - optional TTL for connections set in seconds
+  - the value is stored as `ttl` field on the row (you are responsible for enabling TTL on given field)
 
 ### `DynamoDBEventStore: IEventStore`
 
@@ -110,6 +113,9 @@ Stores subscription operations to a subscription operations table as `subscripti
 
 - **subscriptionsTableName** (`string`, `optional`, `default: 'Subscriptions'`)
 - **subscriptionOperationsTableName** - (`string`, `optional`, `default: 'SubscriptionOperations'`)
+- **ttl** (`number`, `optional`, `default: 2 hours`)
+  - optional TTL for subscriptions and subscriptionOperations set in seconds
+  - the value is stored as `ttl` field on the row (you are responsible for enabling TTL on given field)
 
 ### `IConnection`
 

--- a/packages/aws-lambda-graphql/src/__tests__/DynamoDBConnectionManager.test.ts
+++ b/packages/aws-lambda-graphql/src/__tests__/DynamoDBConnectionManager.test.ts
@@ -65,6 +65,21 @@ describe('DynamoDBConnectionManager', () => {
       });
 
       expect(putMock as jest.Mock).toHaveBeenCalledTimes(1);
+      expect(putMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          Item: {
+            createdAt: expect.any(String),
+            data: {
+              context: {},
+              endpoint: '',
+              isInitialized: false,
+            },
+            id: 'id',
+            ttl: expect.any(Number),
+          },
+          TableName: 'Connections',
+        }),
+      );
     });
   });
 

--- a/packages/aws-lambda-graphql/src/__tests__/DynamoDBSubscriptionManager.test.ts
+++ b/packages/aws-lambda-graphql/src/__tests__/DynamoDBSubscriptionManager.test.ts
@@ -94,40 +94,37 @@ describe('DynamoDBSubscriptionManager', () => {
       ).resolves.toBeUndefined();
 
       expect(batchWritePromiseMock).toHaveBeenCalledTimes(1);
-      expect((batchWriteMock as jest.Mock).mock.calls[0][0])
-        .toMatchInlineSnapshot(`
-                Object {
-                  "RequestItems": Object {
-                    "SubscriptionOperations": Array [
-                      Object {
-                        "PutRequest": Object {
-                          "Item": Object {
-                            "event": "name1",
-                            "subscriptionId": "1:1",
-                          },
-                        },
-                      },
-                    ],
-                    "Subscriptions": Array [
-                      Object {
-                        "PutRequest": Object {
-                          "Item": Object {
-                            "connection": Object {
-                              "id": "1",
-                            },
-                            "event": "name1",
-                            "operation": Object {
-                              "operationId": "1",
-                            },
-                            "operationId": "1",
-                            "subscriptionId": "1:1",
-                          },
-                        },
-                      },
-                    ],
+      expect(batchWriteMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          RequestItems: {
+            SubscriptionOperations: [
+              {
+                PutRequest: {
+                  Item: {
+                    event: 'name1',
+                    subscriptionId: '1:1',
+                    ttl: expect.any(Number),
                   },
-                }
-            `);
+                },
+              },
+            ],
+            Subscriptions: [
+              {
+                PutRequest: {
+                  Item: {
+                    connection: { id: '1' },
+                    event: 'name1',
+                    operation: { operationId: '1' },
+                    operationId: '1',
+                    subscriptionId: '1:1',
+                    ttl: expect.any(Number),
+                  },
+                },
+              },
+            ],
+          },
+        }),
+      );
     });
   });
 


### PR DESCRIPTION
### Description

- add optional ttl support for dynamodb connections, subscriptions and subscriptionOperations
- use default value for ttl as 2 hours and make it configurable.

as discussed in #83 