### PR TITLE
feat: filter out ddb expired connections/subscriptions/events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### [Unreleased](https://github.com/michalkvasnicak/aws-lambda-graphql/compare/aws-lambda-graphql@1.0.0-alpha.7...HEAD)
 
+#### Added
+
+- Added support for filtering out expired DynamoDB connections, subscriptions and events, see [#92](https://github.com/michalkvasnicak/aws-lambda-graphql/pull/92).
+
 ### [v1.0.0-alpha.8](https://github.com/michalkvasnicak/aws-lambda-graphql/compare/aws-lambda-graphql@1.0.0-alpha.7...aws-lambda-graphql@1.0.0-alpha.8) - 2020-07-06
 
 #### Added

--- a/README.md
+++ b/README.md
@@ -77,13 +77,22 @@ import {
   DynamoDBSubscriptionManager,
 } from 'aws-lambda-graphql';
 
+/*
+ By default subscriptions and connections use TTL of 2 hours. 
+ This can be changed by `ttl` option in DynamoDBSubscriptionManager and DynamoDBConnectionManager.
+
+ ttl accepts a number in seconds (default is 7200 seconds) or
+ false to turn it off.
+
+ It's your responsibility to set up TTL on your connections and subscriptions tables.
+*/
 const subscriptionManager = new DynamoDBSubscriptionManager();
 const connectionManager = new DynamoDBConnectionManager({
   subscriptionManager,
 });
 ```
 
-**⚠️ in order to clean up stale connections and subscriptions please set up TTL on `ttl` field in Connections, Subscriptions and SubscriptionOperations tables.**
+**⚠️ in order to clean up stale connections and subscriptions please set up TTL on `ttl` field in Connections, Subscriptions and SubscriptionOperations tables. You can turn off the TTL by setting up `ttl` option to `false` in `DynamoDBSubscriptionManager` and `DynamoDBConnectionManager`.**
 
 Redis:
 
@@ -119,6 +128,14 @@ import {
   DynamoDBSubscriptionManager,
 } from 'aws-lambda-graphql';
 
+/*
+ By default event stores uses TTL of 2 hours on every event. 
+ This can be changed by `ttl` option in DynamoDBEventStore.
+ ttl accepts a number in seconds (default is 7200 seconds) or
+ false to turn it off.
+
+ It's your responsibility to set up TTL on your events table.
+*/
 const eventStore = new DynamoDBEventStore();
 const subscriptionManager = new DynamoDBSubscriptionManager();
 const connectionManager = new DynamoDBConnectionManager({
@@ -128,7 +145,7 @@ const connectionManager = new DynamoDBConnectionManager({
 
 That's it for now. Our `eventStore` will use DynamoDB to store messages that we want to broadcast to all subscribed clients.
 
-**⚠️ in order to clean up old events, please set up TTL on `ttl` field in Events store table**
+**⚠️ in order to clean up old events, please set up TTL on `ttl` field in Events store table. This can be turned off by setting up the `ttl` option to `false`.**
 
 #### 1.3 Setting up the GraphQL schema
 

--- a/packages/aws-lambda-graphql/src/__tests__/DynamoDBEventProcessor.test.ts
+++ b/packages/aws-lambda-graphql/src/__tests__/DynamoDBEventProcessor.test.ts
@@ -9,6 +9,7 @@ import { SERVER_EVENT_TYPES } from '../protocol';
 import { ISubscriber } from '../types';
 import { Server } from '../Server';
 import { PubSub } from '../PubSub';
+import { computeTTL } from '../helpers';
 
 const query = parse(/* GraphQL */ `
   subscription Test($authorId: ID) {
@@ -17,7 +18,7 @@ const query = parse(/* GraphQL */ `
 `);
 
 describe('DynamoDBEventProcessor', () => {
-  it(' payload as JSON', async () => {
+  it('supports payload as JSON', async () => {
     const connectionManager = {
       sendToConnection: jest.fn(),
     };
@@ -143,7 +144,7 @@ describe('DynamoDBEventProcessor', () => {
     );
   });
 
-  it(' payload as object', async () => {
+  it('supports payload as object', async () => {
     const connectionManager = {
       sendToConnection: jest.fn(),
     };
@@ -325,5 +326,142 @@ describe('DynamoDBEventProcessor', () => {
       event: expect.any(Object),
       lambdaContext: expect.any(Object),
     });
+  });
+
+  it('skips expired events', async () => {
+    const connectionManager = {
+      sendToConnection: jest.fn(),
+    };
+    const subscriptionManager = {
+      subscribersByEventName: jest.fn(() => ({
+        [$$asyncIterator]: () =>
+          createAsyncIterator([
+            [
+              {
+                connection: { id: '1', data: {} } as any,
+                event: 'test',
+                operationId: '1',
+                operation: { query, variables: { authorId: '1' } },
+              },
+              {
+                connection: { id: '2', data: {} } as any,
+                event: 'test',
+                operationId: '1',
+                operation: { query, variables: { authorId: '2' } },
+              },
+              {
+                connection: { id: '3', data: {} } as any,
+                event: 'test',
+                operationId: '1',
+                operation: { query, variables: { authorId: '2' } },
+              },
+              {
+                connection: { id: '4', data: {} } as any,
+                event: 'test',
+                operationId: '1',
+                operation: { query, variables: { authorId: '1' } },
+              },
+              {
+                connection: {
+                  id: '5',
+                  data: { context: { authorId: '2' } },
+                } as any,
+                event: 'test',
+                operationId: '1',
+                operation: { query, variables: {} },
+              },
+            ] as ISubscriber[],
+          ]),
+      })),
+    };
+
+    const server = new Server({
+      context: {
+        // becuase our test schema relies on this context
+        pubSub: new PubSub({ eventStore: {} as any }),
+      },
+      connectionManager: connectionManager as any,
+      eventProcessor: new DynamoDBEventProcessor(),
+      schema: createSchema(),
+      subscriptionManager: subscriptionManager as any,
+    });
+    const eventProcessor = server.createEventHandler();
+
+    const Records: DynamoDBRecord[] = [
+      {
+        dynamodb: {
+          NewImage: DynamoDB.Converter.marshall({
+            event: 'test',
+            payload: JSON.stringify({ authorId: '1', text: 'test 1' }),
+            ttl: computeTTL(-1),
+          }) as any,
+        },
+        eventName: 'INSERT',
+      },
+      {
+        dynamodb: {
+          NewImage: DynamoDB.Converter.marshall({
+            event: 'test',
+            payload: JSON.stringify({ authorId: '2', text: 'test 2' }),
+            ttl: computeTTL(10),
+          }) as any,
+        },
+        eventName: 'INSERT',
+      },
+      {
+        dynamodb: {
+          NewImage: DynamoDB.Converter.marshall({
+            event: 'test',
+            payload: JSON.stringify({ authorId: '1', text: 'test 3' }),
+          }) as any,
+        },
+        eventName: 'INSERT',
+      },
+    ];
+
+    // now process events
+    await eventProcessor({ Records }, {} as any, {} as any);
+
+    expect(connectionManager.sendToConnection).toHaveBeenCalledTimes(5);
+    expect(connectionManager.sendToConnection).toHaveBeenCalledWith(
+      { id: '2', data: {} },
+      formatMessage({
+        id: '1',
+        payload: { data: { textFeed: 'test 2' } },
+        type: SERVER_EVENT_TYPES.GQL_DATA,
+      }),
+    );
+    expect(connectionManager.sendToConnection).toHaveBeenCalledWith(
+      { id: '3', data: {} },
+      formatMessage({
+        id: '1',
+        payload: { data: { textFeed: 'test 2' } },
+        type: SERVER_EVENT_TYPES.GQL_DATA,
+      }),
+    );
+    expect(connectionManager.sendToConnection).toHaveBeenCalledWith(
+      { id: '5', data: { context: { authorId: '2' } } },
+      formatMessage({
+        id: '1',
+        payload: { data: { textFeed: 'test 2' } },
+        type: SERVER_EVENT_TYPES.GQL_DATA,
+      }),
+    );
+    expect(connectionManager.sendToConnection).toHaveBeenCalledWith(
+      { id: '1', data: {} },
+      formatMessage({
+        id: '1',
+        payload: { data: { textFeed: 'test 3' } },
+        type: SERVER_EVENT_TYPES.GQL_DATA,
+      }),
+    );
+    expect(connectionManager.sendToConnection).toHaveBeenCalledWith(
+      { id: '4', data: {} },
+      formatMessage({
+        id: '1',
+        payload: { data: { textFeed: 'test 3' } },
+        type: SERVER_EVENT_TYPES.GQL_DATA,
+      }),
+    );
   });
 });

--- a/packages/aws-lambda-graphql/src/__tests__/DynamoDBEventStore.test.ts
+++ b/packages/aws-lambda-graphql/src/__tests__/DynamoDBEventStore.test.ts
@@ -35,4 +35,28 @@ describe('DynamoDBEventStore', () => {
       }),
     );
   });
+
+  it('supports turning off the TTL', async () => {
+    const eventStore = new DynamoDBEventStore({
+      ttl: false,
+    });
+
+    await expect(
+      eventStore.publish({
+        event: 'test',
+        payload: {
+          custom: true,
+        },
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(putPromiseMock).toHaveBeenCalledTimes(1);
+    expect(putMock).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        Item: expect.objectContaining({
+          ttl: expect.any(Number),
+        }),
+      }),
+    );
+  });
 });

--- a/packages/aws-lambda-graphql/src/__tests__/DynamoDBSubscriptionManager.test.ts
+++ b/packages/aws-lambda-graphql/src/__tests__/DynamoDBSubscriptionManager.test.ts
@@ -126,6 +126,48 @@ describe('DynamoDBSubscriptionManager', () => {
         }),
       );
     });
+
+    it('supports turning off ttl', async () => {
+      const subscriptionManager = new DynamoDBSubscriptionManager({
+        ttl: false,
+      });
+
+      (batchWritePromiseMock as jest.Mock).mockResolvedValueOnce({});
+
+      await expect(
+        subscriptionManager.subscribe(
+          ['name1'],
+          { id: '1' } as any,
+          { operationId: '1' } as any,
+        ),
+      ).resolves.toBeUndefined();
+
+      expect(batchWritePromiseMock).toHaveBeenCalledTimes(1);
+      expect(batchWriteMock).not.toHaveBeenCalledWith(
+        expect.objectContaining({
+          RequestItems: {
+            SubscriptionOperations: [
+              {
+                PutRequest: {
+                  Item: {
+                    ttl: expect.any(Number),
+                  },
+                },
+              },
+            ],
+            Subscriptions: [
+              {
+                PutRequest: {
+                  Item: {
+                    ttl: expect.any(Number),
+                  },
+                },
+              },
+            ],
+          },
+        }),
+      );
+    });
   });
 
   describe('unsubscribe', () => {

--- a/packages/aws-lambda-graphql/src/helpers/isTTLExpired.ts
+++ b/packages/aws-lambda-graphql/src/helpers/isTTLExpired.ts
@@ -1,0 +1,7 @@
+export function isTTLExpired(ttl?: null | undefined | false | number): boolean {
+  if (ttl == null || ttl === false) {
+    return false;
+  }
+
+  return ttl * 1000 < Date.now();
+}


### PR DESCRIPTION
This PR introduces a support for filtering out expired events from DynamoDB and also filters out expired connections and subscriptions.

Closes #91 