### PR TITLE
feat: remove multiple headers not support by websocket

### DIFF
--- a/packages/aws-lambda-graphql/src/Server.ts
+++ b/packages/aws-lambda-graphql/src/Server.ts
@@ -247,10 +247,11 @@ export class Server<
                       event.multiValueHeaders['Sec-WebSocket-Protocol'],
                   }
                 : undefined,
-              headers: event.headers?.['Sec-WebSocket-Protocol']
+              headers: event.headers?.['Sec-WebSocket-Protocol'].includes(
+                'graphql-ws',
+              )
                 ? {
-                    'Sec-WebSocket-Protocol':
-                      event.headers['Sec-WebSocket-Protocol'],
+                    'Sec-WebSocket-Protocol': 'graphql-ws',
                   }
                 : undefined,
               statusCode: 200,


### PR DESCRIPTION
PR following the modifications you made after the issue about returning empty Sec-Webprotocol (#93)

The changes you made throwed a new error that made the problem a little more understandable.

Looks like it's not possible to return a few headers even if you receive multiple. Server has to chose only one protocol he wants to give back to the client. 

I think "graphql-ws" is the best to return since you need to use it in subscription-transport-ws

https://github.com/apollographql/subscriptions-transport-ws/blob/0e81e9e45929db2f4d2699cf34229fb4cb2144e8/src/protocol.ts#L1


Error received on Chrome : Error during WebSocket handshake: 'Sec-WebSocket-Protocol' header must not appear more than once in a response




