### PR TITLE
feat: remove multiValueHeader not supported by WebSocket

### DIFF
--- a/packages/aws-lambda-graphql/src/Server.ts
+++ b/packages/aws-lambda-graphql/src/Server.ts
@@ -239,14 +239,6 @@ export class Server<
 
             return {
               body: '',
-              multiValueHeaders: event.multiValueHeaders?.[
-                'Sec-WebSocket-Protocol'
-              ]
-                ? {
-                    'Sec-WebSocket-Protocol':
-                      event.multiValueHeaders['Sec-WebSocket-Protocol'],
-                  }
-                : undefined,
               headers: event.headers?.['Sec-WebSocket-Protocol'].includes(
                 'graphql-ws',
               )

--- a/packages/aws-lambda-graphql/src/__tests__/Server.test.ts
+++ b/packages/aws-lambda-graphql/src/__tests__/Server.test.ts
@@ -227,37 +227,6 @@ describe('Server', () => {
         );
       });
 
-      it('passes provided Sec-WebSocket-Protocol multi header', async () => {
-        (connectionManager.registerConnection as jest.Mock).mockResolvedValueOnce(
-          {},
-        );
-
-        await expect(
-          handler(
-            {
-              multiValueHeaders: {
-                'Sec-WebSocket-Protocol': ['graphql-ws', 'graphql-ws1'],
-              },
-              requestContext: {
-                connectionId: '1',
-                domainName: 'domain',
-                routeKey: '$connect',
-                stage: 'stage',
-              } as any,
-            } as any,
-            {} as any,
-          ),
-        ).resolves.toEqual(
-          expect.objectContaining({
-            body: '',
-            multiValueHeaders: {
-              'Sec-WebSocket-Protocol': ['graphql-ws', 'graphql-ws1'],
-            },
-            statusCode: 200,
-          }),
-        );
-      });
-
       it('passes provided Sec-WebSocket-Protocol header', async () => {
         (connectionManager.registerConnection as jest.Mock).mockResolvedValueOnce(
           {},


### PR DESCRIPTION
Removing multiValueHeader not compatible with web-socket and might be source of error in the code.

I should had remove it in the last PR 