### PR TITLE
Enable Cognito (IAM) auth for subscriptions

### DIFF
--- a/packages/aws-lambda-graphql/README.md
+++ b/packages/aws-lambda-graphql/README.md
@@ -48,7 +48,8 @@ All options from Apollo Lambda Server and
 - **onError** (`(err: any) => void`, `optional`) - use to log errors from websocket handler on unknown error
 - **subscriptionManager** (`ISubscriptionManager`, `required`)
 - **subscriptions** (`optional`)
-  - **`onConnect(messagePayload: object, connection: IConnection, event: APIGatewayWebSocketEvent, context: LambdaContext): Promise<boolean|object> | object | boolean`** (`optional`) - Return an object to set a context to your connection object saved in the database e.g. for saving authentication details
+  - **`onWebsocketConnect(connection: IConnection, event: APIGatewayWebSocketEvent, context: LambdaContext): Promise<boolean|object> | object | boolean`** (`optional`) - onWebsocketConnect is called when the Websocket connection is initialized ($connect route).  Return an object to set a context to your connection object saved in the database e.g. for saving authentication details. This is especially useful to get authentication details (API GW authorizers only run in $connect route)
+  - **`onConnect(messagePayload: object, connection: IConnection, event: APIGatewayWebSocketEvent, context: LambdaContext): Promise<boolean|object> | object | boolean`** (`optional`) - onConnect is called when the GraphQL connection is initialized (connection_init message). Return an object to set a context to your connection object saved in the database e.g. for saving authentication details. NOTE: This is not the websocket $connect route, see onWebsocketConnect for the $connect route.
   - **`onOperation(message: OperationRequest, params: ExecutionParams, connection: IConnection): Promise<ExecutionParams>|ExecutionParams`** (`optional`)
   - **`onOperationComplete(connection: IConnection, operationId: string): void`** (`optional`)
   - **`onDisconnect(connection: IConnection): void`** (`optional`)

--- a/packages/aws-lambda-graphql/src/Server.ts
+++ b/packages/aws-lambda-graphql/src/Server.ts
@@ -283,11 +283,7 @@ export class Server<
                   payload: { message: err.message },
                 });
 
-                await this.connectionManager.sendToConnection(
-                  connection,
-                  errorResponse,
-                );
-                await this.connectionManager.closeConnection(connection);
+                await this.connectionManager.unregisterConnection(connection);
 
                 return {
                   body: errorResponse,

--- a/packages/aws-lambda-graphql/src/Server.ts
+++ b/packages/aws-lambda-graphql/src/Server.ts
@@ -401,7 +401,7 @@ export class Server<
               const connectionData = {
                 ...connection.data,
                 context: {
-                  ...connection.data.context,
+                  ...connection.data?.context,
                   ...newConnectionContext,
                 },
                 isInitialized: true,

--- a/packages/aws-lambda-graphql/src/Server.ts
+++ b/packages/aws-lambda-graphql/src/Server.ts
@@ -67,11 +67,11 @@ export interface ServerConfig<
       connection: IConnection,
       operationId: string,
     ) => void;
-  /**
+    /**
      * onWebsocketConnect is called when the Websocket connection is initialized ($connect route).
      * Return an object to set a context to your connection object saved in the database e.g. for saving authentication details.
      * This is especially useful to get authentication details (API GW authorizers only run in $connect route)
-     * 
+     *
      */
     onWebsocketConnect?: (
       connection: IConnection,
@@ -84,7 +84,7 @@ export interface ServerConfig<
     /**
      * onConnect is called when the GraphQL connection is initialized (connection_init message).
      * Return an object to set a context to your connection object saved in the database e.g. for saving authentication details.
-     * 
+     *
      * NOTE: This is not the websocket $connect route, see onWebsocketConnect for the $connect route
      *
      */
@@ -248,9 +248,7 @@ export class Server<
         // based on routeKey, do actions
         switch (event.requestContext.routeKey) {
           case '$connect': {
-            const {
-              onWebsocketConnect,
-            } = this.subscriptionOptions || {};
+            const { onWebsocketConnect } = this.subscriptionOptions || {};
 
             // register connection
             // if error is thrown during registration, connection is rejected
@@ -262,7 +260,7 @@ export class Server<
               connectionId: event.requestContext.connectionId,
             });
 
-            let newConnectionContext = {}
+            let newConnectionContext = {};
 
             if (onWebsocketConnect) {
               try {
@@ -275,7 +273,7 @@ export class Server<
                 if (result === false) {
                   throw new Error('Prohibited connection!');
                 } else if (result !== null && typeof result === 'object') {
-                  newConnectionContext = result
+                  newConnectionContext = result;
                 }
               } catch (err) {
                 const errorResponse = formatMessage({
@@ -295,7 +293,7 @@ export class Server<
             // set connection context which will be available during graphql execution
             const connectionData = {
               ...connection.data,
-              context: newConnectionContext
+              context: newConnectionContext,
             };
 
             await this.connectionManager.setConnectionData(
@@ -402,7 +400,10 @@ export class Server<
               // set connection context which will be available during graphql execution
               const connectionData = {
                 ...connection.data,
-                context: {...connection.data.context, ...newConnectionContext},
+                context: {
+                  ...connection.data.context,
+                  ...newConnectionContext,
+                },
                 isInitialized: true,
               };
 

--- a/packages/aws-lambda-graphql/src/__tests__/Server.test.ts
+++ b/packages/aws-lambda-graphql/src/__tests__/Server.test.ts
@@ -169,9 +169,10 @@ describe('Server', () => {
       it('recover from missing connection on quick succession of $connect and GQL_CONNECTION_INIT message on offline server', async () => {
         // Mock the connection database flow
         let connection;
-        (connectionManager.registerConnection as jest.Mock).mockImplementationOnce(
-          (c) => {
+        (connectionManager.registerConnection as jest.Mock).mockImplementation(
+          async (c) => {
             connection = c;
+            return connection;
           },
         );
         (connectionManager.hydrateConnection as jest.Mock).mockImplementationOnce(
@@ -228,7 +229,7 @@ describe('Server', () => {
       });
 
       it('passes provided Sec-WebSocket-Protocol header', async () => {
-        (connectionManager.registerConnection as jest.Mock).mockResolvedValueOnce(
+        (connectionManager.registerConnection as jest.Mock).mockResolvedValue(
           {},
         );
 


### PR DESCRIPTION
Hey..

We use IAM for our auth, and have been using it with this lib for normal queries and mutations without issues. Getting started with subscriptions now, and had to do a little hack to be able to access the IAM info. Thought I'd share it with you in case you find it useful.

I wasn't sure if I could put this info inside connection.data.context, so I just left it in connection.data.identity

The way I am using this is in onConnect, I access the identity data from the connection object, I build my user context, and return it from onConnect, then I have it accessible in the resolvers.

Not sure if that's the most straightforward way to weave the identity data down to resolvers, happy to hear of better ways to do it.

PS: Thanks for the great library, it's saved our team a lot of work and time, and it's just a pleasure to use.

Cheers!

Pepe