### PR TITLE
Allow changing subscription name

### DIFF
--- a/packages/aws-lambda-graphql/README.md
+++ b/packages/aws-lambda-graphql/README.md
@@ -120,6 +120,10 @@ Stores subscription operations to a subscription operations table as `subscripti
 - **ttl** (`number`, `optional`, `default: 2 hours`)
   - optional TTL for subscriptions and subscriptionOperations set in seconds
   - the value is stored as `ttl` field on the row (you are responsible for enabling TTL on given field)
+- **getSubscriptionNameFromEvent** (`function`, `optional`, `default: '(event: ISubscriptionEvent) => event.event'`)
+  - Get the subscription name from the event
+- **getSubscriptionNameFromConnection** (`function`, `optional`, `default: '(name: string, connection: IConnection) => name'`)
+  - Get the subscription name from the subscription connection
 
 ### `IConnection`
 

--- a/packages/aws-lambda-graphql/src/DynamoDBEventProcessor.ts
+++ b/packages/aws-lambda-graphql/src/DynamoDBEventProcessor.ts
@@ -67,8 +67,8 @@ export class DynamoDBEventProcessor<TServer extends Server = Server>
         //  - if the are no more subscriptions, process next event
         // make sure that you won't throw any errors otherwise dynamo will call
         // handler with same events again
-        for await (const subscribers of subscriptionManager.subscribersByEventName(
-          event.event,
+        for await (const subscribers of subscriptionManager.subscribersByEvent(
+          event,
         )) {
           const promises = subscribers
             .map(async (subscriber) => {

--- a/packages/aws-lambda-graphql/src/MemoryEventProcessor.ts
+++ b/packages/aws-lambda-graphql/src/MemoryEventProcessor.ts
@@ -37,8 +37,8 @@ export class MemoryEventProcessor<TServer extends Server = Server>
         //  - if the are no more subscriptions, process next event
         // make sure that you won't throw any errors otherwise dynamo will call
         // handler with same events again
-        for await (const subscribers of subscriptionManager.subscribersByEventName(
-          event.event,
+        for await (const subscribers of subscriptionManager.subscribersByEvent(
+          event,
         )) {
           const promises = subscribers
             .map(async (subscriber) => {

--- a/packages/aws-lambda-graphql/src/MemorySubscriptionManager.ts
+++ b/packages/aws-lambda-graphql/src/MemorySubscriptionManager.ts
@@ -1,7 +1,6 @@
 import { createAsyncIterator } from 'iterall';
 import {
   IConnection,
-  IdentifiedOperationRequest,
   ISubscriber,
   ISubscriptionEvent,
   ISubscriptionManager,

--- a/packages/aws-lambda-graphql/src/MemorySubscriptionManager.ts
+++ b/packages/aws-lambda-graphql/src/MemorySubscriptionManager.ts
@@ -1,7 +1,9 @@
 import { createAsyncIterator } from 'iterall';
 import {
   IConnection,
+  IdentifiedOperationRequest,
   ISubscriber,
+  ISubscriptionEvent,
   ISubscriptionManager,
   OperationRequest,
 } from './types';
@@ -11,18 +13,53 @@ if (Symbol.asyncIterator === undefined) {
   (Symbol as any).asyncIterator = Symbol.for('asyncIterator');
 }
 
+interface MemorySubscriptionManagerOptions {
+  /**
+   * Optional function that can get subscription name from event
+   *
+   * Default is (event: ISubscriptionEvent) => event.event
+   *
+   * Useful for multi-tenancy
+   */
+  getSubscriptionNameFromEvent?: (event: ISubscriptionEvent) => string;
+  /**
+   * Optional function that can get subscription name from subscription connection
+   *
+   * Default is (name: string, connection: IConnection) => name
+   *
+   * Useful for multi-tenancy
+   */
+  getSubscriptionNameFromConnection?: (
+    name: string,
+    connection: IConnection,
+  ) => string;
+}
+
 export class MemorySubscriptionManager implements ISubscriptionManager {
   private subscriptions: Map<string, ISubscriber[]>;
 
-  constructor() {
+  private getSubscriptionNameFromEvent: (event: ISubscriptionEvent) => string;
+
+  private getSubscriptionNameFromConnection: (
+    name: string,
+    connection: IConnection,
+  ) => string;
+
+  constructor({
+    getSubscriptionNameFromEvent = (event) => event.event,
+    getSubscriptionNameFromConnection = (name) => name,
+  }: MemorySubscriptionManagerOptions = {}) {
     this.subscriptions = new Map();
+    this.getSubscriptionNameFromEvent = getSubscriptionNameFromEvent;
+    this.getSubscriptionNameFromConnection = getSubscriptionNameFromConnection;
   }
 
-  subscribersByEventName = (
-    name: string,
+  subscribersByEvent = (
+    event: ISubscriptionEvent,
   ): AsyncIterable<ISubscriber[]> & AsyncIterator<ISubscriber[]> => {
     return {
       [Symbol.asyncIterator]: () => {
+        const name = this.getSubscriptionNameFromEvent(event);
         const subscriptions = this.subscriptions.get(name) || [];
 
         const subscribers = subscriptions.filter(
@@ -39,7 +76,8 @@ export class MemorySubscriptionManager implements ISubscriptionManager {
     connection: IConnection,
     operation: OperationRequest & { operationId: string },
   ): Promise<void> => {
-    names.forEach((name) => {
+    names.forEach((n) => {
+      const name = this.getSubscriptionNameFromConnection(n, connection);
       const subscriptions = this.subscriptions.get(name);
       const subscription = {
         connection,

--- a/packages/aws-lambda-graphql/src/__tests__/DynamoDBEventProcessor.test.ts
+++ b/packages/aws-lambda-graphql/src/__tests__/DynamoDBEventProcessor.test.ts
@@ -23,7 +23,7 @@ describe('DynamoDBEventProcessor', () => {
       sendToConnection: jest.fn(),
     };
     const subscriptionManager = {
-      subscribersByEventName: jest.fn(() => ({
+      subscribersByEvent: jest.fn(() => ({
         [$$asyncIterator]: () =>
           createAsyncIterator([
             [
@@ -149,7 +149,7 @@ describe('DynamoDBEventProcessor', () => {
       sendToConnection: jest.fn(),
     };
     const subscriptionManager = {
-      subscribersByEventName: jest.fn(() => ({
+      subscribersByEvent: jest.fn(() => ({
         [$$asyncIterator]: () =>
           createAsyncIterator([
             [
@@ -279,7 +279,7 @@ describe('DynamoDBEventProcessor', () => {
       sendToConnection: jest.fn(),
     };
     const subscriptionManager = {
-      subscribersByEventName: jest.fn(() => ({
+      subscribersByEvent: jest.fn(() => ({
         [$$asyncIterator]: () =>
           createAsyncIterator([
             [
@@ -333,7 +333,7 @@ describe('DynamoDBEventProcessor', () => {
       sendToConnection: jest.fn(),
     };
     const subscriptionManager = {
-      subscribersByEventName: jest.fn(() => ({
+      subscribersByEvent: jest.fn(() => ({
         [$$asyncIterator]: () =>
           createAsyncIterator([
             [

--- a/packages/aws-lambda-graphql/src/__tests__/DynamoDBSubscriptionManager.test.ts
+++ b/packages/aws-lambda-graphql/src/__tests__/DynamoDBSubscriptionManager.test.ts
@@ -38,9 +38,10 @@ describe('DynamoDBSubscriptionManager', () => {
       let pages = 0;
 
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      for await (const page of subscriptionManager.subscribersByEvent(
-        { event: 'test', payload: {} },
-      )) {
+      for await (const page of subscriptionManager.subscribersByEvent({
+        event: 'test',
+        payload: {},
+      })) {
         pages++;
       }
 
@@ -68,9 +69,10 @@ describe('DynamoDBSubscriptionManager', () => {
       let pages = 0;
 
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      for await (const page of subscriptionManager.subscribersByEvent(
-        { event: 'test', payload: {} },
-      )) {
+      for await (const page of subscriptionManager.subscribersByEvent({
+        event: 'test',
+        payload: {},
+      })) {
         pages++;
       }
 

--- a/packages/aws-lambda-graphql/src/__tests__/DynamoDBSubscriptionManager.test.ts
+++ b/packages/aws-lambda-graphql/src/__tests__/DynamoDBSubscriptionManager.test.ts
@@ -29,7 +29,7 @@ describe('DynamoDBSubscriptionManager', () => {
     transactWritePromiseMock.mockReset();
   });
 
-  describe('subscribersByEventName', () => {
+  describe('subscribersByEvent', () => {
     it('works correctly for emty query result', async () => {
       const subscriptionManager = new DynamoDBSubscriptionManager();
 
@@ -38,8 +38,8 @@ describe('DynamoDBSubscriptionManager', () => {
       let pages = 0;
 
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      for await (const page of subscriptionManager.subscribersByEventName(
-        'test',
+      for await (const page of subscriptionManager.subscribersByEvent(
+        { event: 'test', payload: {} },
       )) {
         pages++;
       }
@@ -68,8 +68,8 @@ describe('DynamoDBSubscriptionManager', () => {
       let pages = 0;
 
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      for await (const page of subscriptionManager.subscribersByEventName(
-        'test',
+      for await (const page of subscriptionManager.subscribersByEvent(
+        { event: 'test', payload: {} },
       )) {
         pages++;
       }

--- a/packages/aws-lambda-graphql/src/__tests__/RedisSubscriptionManager.test.ts
+++ b/packages/aws-lambda-graphql/src/__tests__/RedisSubscriptionManager.test.ts
@@ -26,9 +26,10 @@ describe('RedisSubscriptionManager', () => {
       let pages = 0;
 
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      for await (const page of subscriptionManager.subscribersByEventName(
-        'test',
-      )) {
+      for await (const page of subscriptionManager.subscribersByEvent({
+        event: 'test',
+        payload: '',
+      })) {
         pages++;
       }
 
@@ -50,9 +51,10 @@ describe('RedisSubscriptionManager', () => {
       let pages = 0;
 
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      for await (const page of subscriptionManager.subscribersByEventName(
-        'test',
-      )) {
+      for await (const page of subscriptionManager.subscribersByEvent({
+        event: 'test',
+        payload: '',
+      })) {
         pages++;
       }
 

--- a/packages/aws-lambda-graphql/src/types/subscriptions.ts
+++ b/packages/aws-lambda-graphql/src/types/subscriptions.ts
@@ -19,7 +19,7 @@ export interface ISubscriptionManager {
    *
    * @param name
    */
-  subscribersByEventName(name: string): AsyncIterable<ISubscriber[]>;
+  subscribersByEvent(event: ISubscriptionEvent): AsyncIterable<ISubscriber[]>;
 
   /**
    * Subscribes to events


### PR DESCRIPTION
We are using this in a multi-tenanted application and we want to be able to prefix subscriptions names with the tenant name. This will then allow us to only publish events to certain subscriptions based on the tenancy.

Let me know your thoughts on this.