### PR TITLE
feat(modularity): allow inject log fn in handler

### DIFF
--- a/packages/aws-lambda-graphql/src/DynamoDBEventProcessor.ts
+++ b/packages/aws-lambda-graphql/src/DynamoDBEventProcessor.ts
@@ -117,9 +117,8 @@ export class DynamoDBEventProcessor<TServer extends Server = Server>
               const iterator = getAsyncIterator(iterable);
               const result: IteratorResult<ExecutionResult> = await iterator.next();
 
-              if (this.debug) this.log('Send event ', result);
-
               if (result.value != null) {
+                if (this.debug) this.log('Send event ', result);
                 return connectionManager.sendToConnection(
                   subscriber.connection,
                   formatMessage({

--- a/packages/aws-lambda-graphql/src/DynamoDBEventProcessor.ts
+++ b/packages/aws-lambda-graphql/src/DynamoDBEventProcessor.ts
@@ -14,9 +14,14 @@ import { isTTLExpired } from './helpers/isTTLExpired';
 interface DynamoDBEventProcessorOptions {
   onError?: (err: any) => void;
   /**
-   * Enable console.log
+   * Enable log
    */
   debug?: boolean;
+
+  /**
+   * Allow injecting a logging function
+   */
+  log?: (message: any, ...optionalParams: any[]) => void;
 }
 
 /**
@@ -30,8 +35,11 @@ export class DynamoDBEventProcessor<TServer extends Server = Server>
 
   private debug: boolean;
 
+  private log: (message: any, ...optionalParams: any[]) => void;
+
   constructor(options: DynamoDBEventProcessorOptions = {}) {
-    this.onError = options.onError || ((err: any) => console.log(err));
+    this.log = options.log || console.log;
+    this.onError = options.onError || ((err: any) => this.log(err));
     this.debug = options.debug || false;
   }
 
@@ -54,7 +62,7 @@ export class DynamoDBEventProcessor<TServer extends Server = Server>
 
         // skip if event is expired
         if (isTTLExpired(event.ttl)) {
-          if (this.debug) console.log('Discarded event : TTL expired', event);
+          if (this.debug) this.log('Discarded event : TTL expired', event);
           continue;
         }
 
@@ -109,7 +117,7 @@ export class DynamoDBEventProcessor<TServer extends Server = Server>
               const iterator = getAsyncIterator(iterable);
               const result: IteratorResult<ExecutionResult> = await iterator.next();
 
-              if (this.debug) console.log('Send event ', result);
+              if (this.debug) this.log('Send event ', result);
 
               if (result.value != null) {
                 return connectionManager.sendToConnection(

--- a/packages/aws-lambda-graphql/src/__tests__/DynamoDBEventProcessor.test.ts
+++ b/packages/aws-lambda-graphql/src/__tests__/DynamoDBEventProcessor.test.ts
@@ -19,6 +19,7 @@ const query = parse(/* GraphQL */ `
 
 describe('DynamoDBEventProcessor', () => {
   it('supports payload as JSON', async () => {
+    const mockLog = jest.fn();
     const connectionManager = {
       sendToConnection: jest.fn(),
     };
@@ -71,7 +72,10 @@ describe('DynamoDBEventProcessor', () => {
         pubSub: new PubSub({ eventStore: {} as any }),
       },
       connectionManager: connectionManager as any,
-      eventProcessor: new DynamoDBEventProcessor(),
+      eventProcessor: new DynamoDBEventProcessor({
+        log: mockLog,
+        debug: true,
+      }),
       schema: createSchema(),
       subscriptionManager: subscriptionManager as any,
     });
@@ -142,6 +146,14 @@ describe('DynamoDBEventProcessor', () => {
         type: SERVER_EVENT_TYPES.GQL_DATA,
       }),
     );
+    expect(mockLog).toHaveBeenCalledWith('Send event ', {
+      done: false,
+      value: {
+        data: {
+          textFeed: 'test 1',
+        },
+      },
+    });
   });
 
   it('supports payload as object', async () => {


### PR DESCRIPTION
Allow injecting a logging function (defaults to console.log)
in DynamoDB event processor

Log send event only if event was really sent (result.value exists)